### PR TITLE
docs(blog): rewrite node-security article to 9.0+ (5-reviewer panel)

### DIFF
--- a/apps/blog/content/articles/getting-started-eslint-plugin-node-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-node-security.md
@@ -1,6 +1,6 @@
 ---
-title: "Runtime Security at Scale: The Node.js Static Analysis Standard"
-description: "The automated standard for Node.js core security. 31 engineering rules to detect weak crypto and system leaks in CI/CD via static analysis."
+title: "MD5, exec(), and Zip Slip: 34 ESLint Rules That Fail Your Node.js CI Before They Ship."
+description: "Weak crypto (MD5/SHA-1/ECB), command injection via exec(), Zip Slip path traversal, Math.random() tokens — Node.js built-in footguns that pass tests and ship as CVEs. 34 CWE-mapped ESLint rules that catch them in CI."
 slug: "getting-started-eslint-plugin-node-security"
 canonical_url: "https://ofriperetz.dev/articles/getting-started-eslint-plugin-node-security"
 devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-crypto-4a8g"
@@ -9,15 +9,12 @@ published_at: "2026-01-02T15:15:04Z"
 edited_at: "2026-02-03T04:59:37Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-eslint-plugin-node-security.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-node-security.png"
-reading_time_minutes: 2
+reading_time_minutes: 9
 tags:
   - "eslint"
   - "node"
   - "security"
   - "cryptography"
-reactions: 0
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,122 +23,277 @@ author:
 series: "The Hardened Stack"
 ---
 
-**Node.js runtime security requires more than just dependencies updates. Here is the automated standard for hardening Node.js core—from crypto safety to process isolation—using 31 deep static analysis rules.**
+Four lines, four CVEs, zero compiler complaints:
 
-## Quick Install
-
-```bash
-npm install --save-dev eslint-plugin-node-security
+```ts
+crypto.createHash("md5").update(password).digest("hex"); // broken hash (CWE-327)
+exec(`convert ${req.query.file} out.png`); // command injection (CWE-78)
+await unzipper.extract({ path: dest }); // Zip Slip path traversal (CWE-22)
+const token = Math.random().toString(36).slice(2); // predictable token (CWE-338)
 ```
 
-## Flat Config
+Every one of these is a property of the **Node.js standard library** — `crypto`,
+`child_process`, `fs`, `Math` — used the easy way instead of the safe way. They
+pass type-checking. They pass unit tests (the test feeds trusted input). Then
+they ship, and a researcher finds them with `grep`.
 
-```javascript
-// eslint.config.js
-import nodeSecurity from "eslint-plugin-node-security";
+`eslint-plugin-node-security` reads those call sites and fails CI on the
+dangerous shape. It's **34 rules** spanning weak crypto, command/eval injection,
+filesystem traversal, SSRF, supply-chain, and secrets-at-rest — each pinned to a
+CWE, CVSS, and compliance tags. (It also **absorbed the deprecated
+`eslint-plugin-crypto`** — all the cipher/hash/randomness rules live here now.)
 
-export default [nodeSecurity.configs.recommended];
-```
+This guide walks the crypto footguns, command injection, Zip Slip, the full
+34-rule map, and exact install/engine support.
 
-## Run ESLint
+---
 
-```bash
-npx eslint .
-```
+## TL;DR
 
-You'll see output like:
+- **34 rules**, each carrying a `CWE` id, CVSS, and compliance tags
+  (PCI-DSS / HIPAA / SOC2 / …).
+- **2 presets**: `recommended` (20 rules, mixed severity — the production
+  baseline) and `strict` (all 34 as errors).
+- **Flat-config**, CommonJS, ESLint `8 || 9 || 10`, Node `>= 18`. AST-based — it
+  lints source; no runtime peers. The former `eslint-plugin-crypto` is
+  consolidated here (deprecated → use `node-security`).
 
-```bash
-src/auth/hash.ts
-  15:27 error  🔒 CWE-328 CVSS:7.5 | Weak hash algorithm: MD5
-               [node-security/no-weak-hash-algorithm] Use crypto.createHash('sha256')
+---
 
-src/api/exec.ts
-  10:5  error  🔒 CWE-78 | Detected child process execution
-               [node-security/detect-child-process] Avoid exec(), use spawn() or execFile()
-```
+## The crypto footguns
 
-## Rule Overview
+Node's `crypto` API will happily hand you broken primitives. Several rules,
+mostly **CWE-327** (broken/risky algorithm), draw the line:
 
-| Category             | Rules | Examples                           |
-| -------------------- | ----- | ---------------------------------- |
-| **Cryptography**     | 12    | Weak hashes, static IVs, ECB mode  |
-| **System & Process** | 5     | `exec()`, `eval()`, unsafe require |
-| **File System**      | 6     | Zip Slip, TOCTOU, path injection   |
-| **Best Practices**   | 8     | PII in logs, insecure temp storage |
-
-## Quick Wins
-
-### 1. Cryptography
-
-```javascript
-// ❌ Weak hash
+```ts
+// ❌ no-weak-hash-algorithm (CWE-327) — MD5/SHA-1 are collision-broken
 crypto.createHash("md5").update(data);
+// ❌ no-ecb-mode (CWE-327) — ECB leaks plaintext structure
+crypto.createCipheriv("aes-256-ecb", key, null);
+// ❌ no-static-iv (CWE-329) — a fixed IV destroys CBC/GCM security
+crypto.createCipheriv("aes-256-gcm", key, FIXED_IV);
+// ❌ no-math-random-crypto (CWE-338) — Math.random() is not a CSPRNG
+const token = Math.random().toString(36).slice(2);
+```
 
-// ✅ Strong hash
+```ts
+// ✅
 crypto.createHash("sha256").update(data);
+crypto.createCipheriv("aes-256-gcm", key, crypto.randomBytes(12)); // unique IV
+const token = crypto.randomBytes(32).toString("hex"); // CSPRNG
 ```
 
-### 2. System Security
+The companion rules cover the rest of the surface: `no-weak-cipher-algorithm`,
+`no-sha1-hash`, `no-insecure-rsa-padding`, `no-deprecated-cipher-method`,
+`no-insecure-key-derivation` (CWE-916, e.g. low-iteration PBKDF2),
+`no-timing-unsafe-compare` (CWE-208, use `crypto.timingSafeEqual`),
+`no-self-signed-certs` (CWE-295), and `no-cryptojs` / `prefer-native-crypto`
+(CWE-1104, prefer the audited native module over `crypto-js`).
 
-```javascript
-// ❌ Shell injection risk
-require("child_process").exec(`ls ${userInput}`);
+---
 
-// ✅ Safer execution
-require("child_process").execFile("ls", [userInput]);
+## Command injection — `detect-child-process` (CWE-78)
+
+```ts
+// ❌ shell string interpolation = command injection
+import { exec } from "node:child_process";
+exec(`convert ${req.query.file} out.png`); // file="x.png; rm -rf /"
 ```
 
-### 3. File System
-
-```javascript
-// ❌ Path traversal risk
-fs.readFile(`/data/${userInput}`, cb);
-
-// ✅ Validated path
-if (isValid(userInput)) fs.readFile(path.join(ROOT, userInput), cb);
+```ts
+// ✅ no shell, arguments as an array — the rule's own fix
+import { execFile } from "node:child_process";
+execFile("convert", [req.query.file, "out.png"], { shell: false });
 ```
 
-## Available Presets
+`exec`/`execSync` run their argument through `/bin/sh`, so any user-controlled
+substring is shell code. `execFile`/`spawn` with an args array and
+`shell: false` pass arguments directly to the binary — there's no shell to
+inject into. `detect-eval-with-expression` (CWE-95) and `no-dynamic-require`
+(CWE-94) close the analogous `eval`/`require()` holes.
 
-```javascript
-import nodeSecurity from "eslint-plugin-node-security";
+---
+
+## Zip Slip — `no-zip-slip` (CWE-22)
+
+Extracting an archive without validating entry paths lets a crafted entry
+(`../../../../etc/cron.d/x`) write **outside** the destination directory:
+
+```ts
+// ❌ no-zip-slip (CWE-22) — entry path is trusted
+zip.extractAllTo(dest);
+```
+
+```ts
+// ✅ resolve each entry and confirm it stays under dest
+const target = path.resolve(dest, entry.name);
+if (!target.startsWith(path.resolve(dest) + path.sep))
+  throw new Error("Zip Slip");
+```
+
+`detect-non-literal-fs-filename` and `no-arbitrary-file-access` (both CWE-22)
+catch the broader "user input reaches an `fs` path" pattern;
+`no-toctou-vulnerability` (CWE-367) catches the check-then-use race.
+
+---
+
+## The full rule set
+
+All 34, grouped, with each rule's declared CWE:
+
+### Cryptography
+
+| Rule                          | CWE      |
+| ----------------------------- | -------- |
+| `no-weak-hash-algorithm`      | CWE-327  |
+| `no-sha1-hash`                | CWE-327  |
+| `no-weak-cipher-algorithm`    | CWE-327  |
+| `no-ecb-mode`                 | CWE-327  |
+| `no-insecure-rsa-padding`     | CWE-327  |
+| `no-deprecated-cipher-method` | CWE-327  |
+| `no-static-iv`                | CWE-329  |
+| `no-insecure-key-derivation`  | CWE-916  |
+| `no-timing-unsafe-compare`    | CWE-208  |
+| `no-self-signed-certs`        | CWE-295  |
+| `no-math-random-crypto`       | CWE-338  |
+| `no-cryptojs-weak-random`     | CWE-338  |
+| `no-cryptojs`                 | CWE-1104 |
+| `prefer-native-crypto`        | CWE-1104 |
+
+### Injection / dynamic execution
+
+| Rule                          | CWE    |
+| ----------------------------- | ------ |
+| `detect-child-process`        | CWE-78 |
+| `detect-eval-with-expression` | CWE-95 |
+| `no-unsafe-dynamic-require`   | CWE-95 |
+| `no-dynamic-require`          | CWE-94 |
+
+### Filesystem & buffers
+
+| Rule                             | CWE     |
+| -------------------------------- | ------- |
+| `no-zip-slip`                    | CWE-22  |
+| `detect-non-literal-fs-filename` | CWE-22  |
+| `no-arbitrary-file-access`       | CWE-22  |
+| `no-toctou-vulnerability`        | CWE-367 |
+| `no-buffer-overread`             | CWE-126 |
+| `no-deprecated-buffer`           | CWE-676 |
+
+### SSRF & supply chain
+
+| Rule                             | CWE      |
+| -------------------------------- | -------- |
+| `no-ssrf`                        | CWE-918  |
+| `detect-suspicious-dependencies` | CWE-506  |
+| `lock-file`                      | CWE-829  |
+| `require-dependency-integrity`   | CWE-494  |
+| `no-dynamic-dependency-loading`  | CWE-1104 |
+
+### Secrets & data-at-rest
+
+| Rule                                | CWE     |
+| ----------------------------------- | ------- |
+| `require-secure-credential-storage` | CWE-312 |
+| `require-storage-encryption`        | CWE-312 |
+| `no-data-in-temp-storage`           | CWE-312 |
+| `require-secure-deletion`           | CWE-459 |
+| `no-pii-in-logs`                    | CWE-359 |
+
+That's all 34 (14 + 4 + 6 + 5 + 5). `recommended` turns on 20 of them (criticals
+as errors, a few as warnings); `strict` turns on all 34.
+
+---
+
+## Install
+
+```bash
+# npm
+npm install --save-dev eslint-plugin-node-security
+# yarn
+yarn add --dev eslint-plugin-node-security
+# pnpm
+pnpm add --save-dev eslint-plugin-node-security
+# bun
+bun add --dev eslint-plugin-node-security
+```
+
+Flat config (`eslint.config.js`):
+
+```js
+// `configs` is a NAMED export; the default export is the plugin object.
+import { configs } from "eslint-plugin-node-security";
 
 export default [
-  // Recommended (Low false positives, High impact)
-  nodeSecurity.configs.recommended,
-
-  // All Rules (Stricter auditing)
-  nodeSecurity.configs.all,
+  configs.recommended, // 20 rules — production baseline
+  // configs.strict,    // all 34 as errors
 ];
 ```
 
-## Quick Reference
+Run it — findings carry the CWE, OWASP category, CVSS, compliance tags, and fix:
 
-```bash
-# Install
-npm install --save-dev eslint-plugin-node-security
-
-# Config (eslint.config.js)
-import nodeSecurity from 'eslint-plugin-node-security';
-export default [nodeSecurity.configs.recommended];
-
-# Run
-npx eslint .
+```text
+src/auth/hash.ts
+  4:3  error  🔒 CWE-327 OWASP:A04-Cryptographic CVSS:7.5 | Use of weak hash algorithm: MD5. MD5 is cryptographically broken and unsuitable for security purposes. | CRITICAL [PCI-DSS,HIPAA,ISO27001,NIST-CSF]
+             Fix: Replace with sha256: crypto.createHash("sha256").update(data)
 ```
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+## Compatibility
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
+| Surface              | Support                                                                                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun — plain dev dependency                                                                                                                     |
+| **Node**             | `>= 18.0.0`                                                                                                                                                     |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                                                                                                  |
+| **Module system**    | CommonJS — loads from both `eslint.config.js` and `eslint.config.mjs`                                                                                           |
+| **Runtime peers**    | None — it lints source AST                                                                                                                                      |
+| **Replaces**         | `eslint-plugin-crypto` (deprecated) — its cipher/hash/randomness rules are consolidated here                                                                    |
+| **Oxlint**           | Loads under Oxlint's JS-plugin runner via the `interlace-node-security` port, with ESLint↔Oxlint parity gated in CI. The full 34-rule set runs on ESLint today. |
 
 ---
 
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
+## What it does — and doesn't — see
 
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+- **Source patterns, not runtime.** It flags `createHash("md5")`, `exec(\`…${x}\`)`,
+and an unguarded `extract()`. It can't confirm the key in your KMS is rotated
+  or that your archive source is trusted — it removes the "we shipped MD5 / a
+  shell string" failure mode at the call site.
+- **Taint detection has edges.** The injection and fs rules track user input
+  toward a sink with configurable patterns; tune them rather than assuming the
+  defaults are exhaustive, and pair with runtime input validation.
+
+---
+
+## Where this sits in the ecosystem
+
+The generic security linters flag a few of these (`eval`, obvious `child_process`),
+but they don't carry the CWE/CVSS/compliance metadata a security or audit
+reviewer needs, and they don't cover the crypto surface at this depth.
+`eslint-plugin-node-security` is the dedicated Node.js-stdlib layer — crypto,
+injection, filesystem, SSRF, supply-chain, secrets — and the consolidation home
+for the retired crypto plugin. It's the runtime-foundation member of the
+[Interlace](https://eslint.interlace.tools) family, underneath the
+framework-specific plugins (`-express-security`, `-nestjs-security`, …).
+
+---
+
+## Links
+
+- 📦 [npm: eslint-plugin-node-security](https://www.npmjs.com/package/eslint-plugin-node-security)
+- 📖 [Full rule docs (per-rule CWE + examples)](https://eslint.interlace.tools/docs/security/plugin-node-security/rules)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-node-security)
+
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if your Node.js code does any of the above.
+::
+
+---
+
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack. `eslint-plugin-node-security`
+is its Node.js-standard-library layer.
+
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary
Rewrites `getting-started-eslint-plugin-node-security` from a 2-min install README (panel **4.0**, "Runtime Security at Scale: The X Standard", fabricated "31 rules") into a full walk-through of the **34** node-security rules. Panel **≥9.0 every lens** (Security 9.5, Growth 9.4, Structure 9.3, min 9.0).

- Hook: "Four lines, four CVEs, zero compiler complaints" — MD5, `exec()`, Zip Slip, non-CSPRNG token, each tagged with its CWE.
- Deep-dives: weak crypto (MD5/ECB/static-IV/CWE-327/329/338), command injection (`detect-child-process` CWE-78 → `execFile` array+`shell:false`), Zip Slip (CWE-22).
- Corrected **31 → 34** (verified by counting the registration object; matches dirs+imports; `recommended`=20 subset, `strict`=34). Full grouped CWE table (14+4+6+5+5). Noted the `eslint-plugin-crypto` consolidation (verified true).
- Named `import { configs }`; byte-exact sample (`CWE-327 OWASP:A04-Cryptographic CVSS:7.5 … [PCI-DSS,HIPAA,ISO27001,NIST-CSF]`, traced through `enrichFromCWE`).

## Test plan
- [x] Prettier; 34-rule grouped table; named import; "31" removed; sample traced to formatter.
- [x] 5-reviewer panel ≥9.0 (min 9.0), no re-run.
- [ ] CI build-test-lint green.

> Note (not this PR): the eslint repo's `node-security/src/index.ts` has parallel-branch WIP that would drop `no-pii-in-logs` (→33). Article is correct vs committed `origin/main` + published v4.2.0 (34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)