### PR TITLE
docs(blog): rewrite hardcoded-secrets (AI auto-fix) article to 9.0+ (5-reviewer panel)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,7 +12,7 @@ useDefault = true
 
 [[allowlists]]
 description = "Fake/example secrets in security article content (teaching demos)"
-paths = ['''apps/web/content/articles/.*\.md$''']
+paths = ['''apps/blog/content/articles/.*\.md$''']
 regexes = [
   '''sk-prod-abc123def456ghi789jkl012mno345pqr678''',
   '''sk_live_abc123xyz789''',

--- a/apps/blog/content/articles/hardcoded-secrets-ai-agents-autofix.md
+++ b/apps/blog/content/articles/hardcoded-secrets-ai-agents-autofix.md
@@ -1,6 +1,6 @@
 ---
-title: "The Secret Management Standard: Automating AI Agent Protection"
-description: "Hardcoded credentials are a governance failure. Learn the static analysis standard for detecting and auto-fixing secrets in AI-native codebases."
+title: "AI Coding Assistants Hardcode Secrets. This ESLint Rule Catches Them — in a Format the AI Can Auto-Fix."
+description: "AI assistants leave demo keys, placeholder passwords, and bare config literals in source — CWE-798 at scale. One ESLint rule catches the hardcoded literal, and its CWE/CVSS/fix message is structured so the same AI can read the error and hoist it to process.env."
 slug: "hardcoded-secrets-ai-agents-autofix"
 canonical_url: "https://ofriperetz.dev/articles/hardcoded-secrets-ai-agents-autofix"
 devto_url: "https://dev.to/ofri-peretz/hardcoded-secrets-the-1-vulnerability-ai-agents-can-auto-fix-47cg"
@@ -9,15 +9,12 @@ published_at: "2025-12-31T05:39:36Z"
 edited_at: "2026-01-11T10:22:03Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fhardcoded-secrets-ai-agents-autofix.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/hardcoded-secrets-ai-agents-autofix.png"
-reading_time_minutes: 2
+reading_time_minutes: 7
 tags:
   - "eslint"
   - "javascript"
   - "security"
   - "devops"
-reactions: 0
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,101 +23,192 @@ author:
 series: "Hardening AI Agents"
 ---
 
-**Hardcoded secrets in AI prompts are a catastrophic governance failure. Here is the automated static analysis standard for detecting and auto-fixing credentials inside your AI-native codebases.**
+Ask an AI assistant to "wire up Stripe" or "connect to the database" and watch
+what it produces:
 
-Every week, secrets leak. API keys committed to GitHub. Database passwords in config files. AWS credentials in environment variable defaults.
-
-**The fix is trivial. The detection is not.**
-
-Until now.
-
-## The Problem
-
-```javascript
-// ❌ This ships to production more than you'd think
-const db = new Pool({
-  host: "prod-db.example.com",
-  user: "admin",
-  password: "super_secret_password_123", // CWE-798
-});
-
-const stripe = new Stripe("sk_live_abc123xyz789"); // Hardcoded API key
+```ts
+const stripe = new Stripe("sk_live_51H8xY2eZvKf..."); // demo key it left in
+const db = new Pool({ password: "changeme" }); // placeholder it forgot to remove
+const JWT_SECRET = "your-secret-key"; // the classic
 ```
 
-These patterns are obvious in isolation. In a 50,000-line codebase? They hide in plain sight.
+Coding assistants optimize for "runs on the first try," and the fastest path to
+runnable code is a literal in place. So they hardcode **demo keys**,
+**placeholder credentials**, and **bare config literals** — at the speed they
+generate everything else. That's **CWE-798** (Use of Hard-coded Credentials),
+and it now enters codebases faster than any human ever added it.
 
-## Why Traditional Tools Fail
+Here's the twist that makes this fixable rather than just alarming: the same
+property that makes AI a prolific _source_ of these bugs — it reads and writes
+structured text — makes it a capable _fixer_. `eslint-plugin-secure-coding`'s
+`no-hardcoded-credentials` rule emits a finding that carries the CWE, CVSS,
+compliance tags, and the exact fix. Feed that back to the assistant and it
+remediates its own output. This is the agentic-CI loop: **AI writes → linter
+flags in machine-readable form → AI fixes.**
 
-| Tool                    | Problem                      |
-| ----------------------- | ---------------------------- |
-| **grep for "password"** | Too many false positives     |
-| **Secret scanners**     | Only catch committed secrets |
-| **Code review**         | Humans miss things           |
+---
 
-## The ESLint Solution
+## TL;DR
 
-```javascript
-// eslint.config.js
-import secureCoding from "eslint-plugin-secure-coding";
+- AI assistants introduce hardcoded secrets (**CWE-798**) at scale — bare demo
+  keys, placeholder passwords, and config literals left in source.
+- `no-hardcoded-credentials` (in `eslint-plugin-secure-coding`) catches them and
+  emits a **structured, CWE-tagged** finding an AI agent can parse and auto-fix.
+- The detector is two-mode (registered key prefixes fire anywhere; generic
+  secrets need a credential-named identifier) so it's quiet enough to run as a
+  CI **error**. Full mechanism in the [secure-coding deep-dive](https://ofriperetz.dev/articles/getting-started-eslint-plugin-secure-coding).
 
-export default [secureCoding.configs.recommended];
+---
+
+## Why the lint error is written for the machine
+
+A human reads `error: hardcoded credential` and sighs. An AI agent reads the
+_structure_ and acts. Run `npx eslint .` and a finding looks like this:
+
+```text
+src/payments.ts
+  4:36  error  🔒 CWE-798 OWASP:A04-Cryptographic CVSS:9.8 | Hard-coded API key detected | CRITICAL [SOC2,PCI-DSS,HIPAA,GDPR]
+              Fix: Use environment variable: process.env.STRIPE_SECRET_KEY or secret management service
 ```
 
-Now run `npx eslint .` and get:
+Every token is a machine signal:
 
-```bash
-src/db.ts
-  5:3  error  🔒 CWE-798 OWASP:A02 CVSS:7.5 | Hardcoded credential detected
-              Fix: Use environment variable: process.env.DATABASE_PASSWORD
-```
+- **`CWE-798`** — a stable, machine-readable vulnerability class the model has
+  seen thousands of times in training; it knows the remediation pattern.
+- **`CVSS:9.8` + `CRITICAL`** — lets an agent prioritize this over a style nit.
+- **`[SOC2,PCI-DSS,HIPAA,GDPR]`** — the compliance frameworks the finding maps
+  to, for an audit trail the agent can cite.
+- **`Fix:`** — the exact transformation (`→ process.env.…`), so the edit is
+  deterministic, not a guess.
 
-## The Fixed Code
+Drop that into Cursor/Copilot/Claude (or an autonomous CI agent) and the fix is
+mechanical: hoist the literal to an environment variable or a secret manager.
+The rule turns a vague "be secure" instruction into a closed, verifiable loop.
 
-```javascript
-// ✅ Secure pattern
-const db = new Pool({
-  host: process.env.DATABASE_HOST,
-  user: process.env.DATABASE_USER,
-  password: process.env.DATABASE_PASSWORD,
-});
+---
 
+## The fix the rule wants
+
+```ts
+// ✅ no literal in source; the secret comes from the environment
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+const db = new Pool({ password: process.env.DATABASE_PASSWORD });
+// for higher assurance: fetch from AWS Secrets Manager / Vault at runtime
 ```
 
-## Why AI Agents Love This Rule
+The rule flags the **bare literal** — `new Stripe("sk_live_…")`,
+`password: "changeme"`, `const JWT_SECRET = "…"` — and its suggested fix hoists
+it to a `process.env` reference, the exact shape the agent should have produced.
+(One deliberate nuance: a value that's _already_ an env read with a literal
+fallback — `process.env.X || "dev-default"` — is treated as **already
+remediated**, since the real secret lives in the environment; that form is the
+rule's accepted output, not a finding. So the thing it catches is the bare,
+env-less literal.)
 
-The error message is structured for AI consumption:
+## How it stays quiet enough to be an error
 
-- **[CWE-798](https://cwe.mitre.org/data/definitions/798.html)**: Machine-readable vulnerability ID
-- **Fix instruction**: Exact pattern to apply
-- **Location**: Precise line and column
+A naive secret scanner drowns you in false positives, which trains everyone
+(human and agent) to ignore it. `no-hardcoded-credentials` makes **two
+different decisions**: registered vendor key prefixes (`sk_live_`, `AKIA…`)
+fire anywhere because they're unambiguous, while a generic high-entropy string
+is only flagged when the surrounding identifier _names_ a credential
+(`apiKey`, `password`, `token`) and clears a length floor. That low
+false-positive rate is what lets you run it as a blocking CI error — and what
+makes an agent trust the signal instead of suppressing it. The
+[secure-coding getting-started](https://ofriperetz.dev/articles/getting-started-eslint-plugin-secure-coding)
+walks the full two-mode mechanism and the other 26 rules in the plugin.
 
-Cursor, Copilot, and Claude can read this and auto-fix without human intervention.
+---
 
-## Quick Install
+## Install
 
 ```bash
-npm install --save-dev eslint-plugin-secure-coding — 89 security rules. Zero hardcoded secrets.
-
----
-
-📦 [npm: eslint-plugin-secure-coding](https://www.npmjs.com/package/eslint-plugin-secure-coding)
-📖 [Rule docs: no-hardcoded-credentials](https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-secure-coding/docs/rules/no-hardcoded-credentials.md)
-
----
-
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
-
-[Explore the full Documentation](https://eslint.interlace.tools)
----
-
-© 2026 Ofri Peretz. All rights reserved.
-
----
-
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+# npm
+npm install --save-dev eslint-plugin-secure-coding
+# yarn
+yarn add --dev eslint-plugin-secure-coding
+# pnpm
+pnpm add --save-dev eslint-plugin-secure-coding
+# bun
+bun add --dev eslint-plugin-secure-coding
 ```
+
+```js
+// eslint.config.js — `configs` is a NAMED export
+import { configs } from "eslint-plugin-secure-coding";
+
+export default [configs.recommended];
+```
+
+Tune it for your repo (e.g. allow fixtures in tests):
+
+```js
+import { configs } from "eslint-plugin-secure-coding";
+
+export default [
+  configs.recommended,
+  {
+    rules: {
+      "secure-coding/no-hardcoded-credentials": [
+        "error",
+        { allowInTests: true },
+      ],
+    },
+  },
+];
+```
+
+---
+
+## Compatibility
+
+| Surface              | Support                                                                                                                                                                |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                                                                                                   |
+| **Node**             | `>= 18.0.0`                                                                                                                                                            |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                                                                                                         |
+| **Module system**    | CommonJS — `eslint.config.js` or `.mjs`                                                                                                                                |
+| **AI assistants**    | the CWE/CVSS/compliance/fix message is plain text in the lint output — consumable by Cursor, Copilot, Claude Code, or an autonomous CI agent with no extra integration |
+
+---
+
+## Honest scope
+
+- **It catches the literal in source, not key validity.** It flags
+  `sk_live_…`; it can't tell a revoked test key from a live one. Rotate anything
+  that was ever committed.
+- **Auto-fix needs a human gate for the secret value.** The agent can hoist the
+  literal to `process.env.X` deterministically, but _where the real secret
+  lives_ (env, Secrets Manager, Vault) is an architectural decision — the rule
+  points at it, you choose it.
+- **One rule, not a secret-scanning platform.** Pair it with a
+  history/secret scanner (commits already pushed) and rotation; this is the
+  pre-merge gate that stops new ones — including the ones your AI just wrote.
+
+---
+
+## Where this sits
+
+This is one rule in `eslint-plugin-secure-coding` (27 framework-agnostic
+"pure coding security" rules; see the
+[full getting-started](https://ofriperetz.dev/articles/getting-started-eslint-plugin-secure-coding)).
+It's part of the [Interlace](https://eslint.interlace.tools) ecosystem —
+domain-specific static analysis whose findings are deliberately structured for
+both humans and the agents now writing most of the code.
+
+- 📦 [npm: eslint-plugin-secure-coding](https://www.npmjs.com/package/eslint-plugin-secure-coding)
+- 📖 [Rule docs: no-hardcoded-credentials](https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-secure-coding)
+
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if your AI assistant has ever left a `"your-secret-key"` literal in your source.
+::
+
+---
+
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack, with findings structured for
+the AI agents now writing the code.
+
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary
Rewrites `hardcoded-secrets-ai-agents-autofix` from a 2-min README (panel **4.4**, broken fence + "89 rules" + a thesis that was **false against source**) into a distinct AI-auto-fix-loop angle on secure-coding's `no-hardcoded-credentials`. Panel **≥9.0 every lens** (Growth 9.4, Structure 9.4, Security 9.3, min 9.3).

- Distinct angle, cross-linked to the secure-coding getting-started (not a dupe): AI assistants are a prolific *source* of CWE-798 bare hardcoded secrets, and the rule's structured CWE/CVSS/fix message closes the agentic-CI loop.
- **Corrected the central thesis**: the rule flags **bare** literals; it deliberately **skips** `process.env.X || "literal"` (PR #144 — env-fallback = already-remediated) and its autofix *produces* that shape. The old draft claimed the `||` fallback was flagged — a green-build example. (The panel caught this; verified against source.)
- Fixed unclosed fence, "89 rules" → 27, wrong `OWASP:A02 CVSS:7.5` → byte-exact `CWE-798 OWASP:A04-Cryptographic CVSS:9.8 [SOC2,PCI-DSS,HIPAA,GDPR]`, "330/100%" footer; named `import { configs }`, `allowInTests`.
- Also fixes the stale `.gitleaks.toml` allowlist path (`apps/web` → `apps/blog`, post web→blog rename).

## Test plan
- [x] Prettier; no `||`-fallback claim; correct sample traced to formatter; 27 rules.
- [x] 5-reviewer panel ≥9.0 (min 9.3).
- [ ] CI build-test-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)