### PR TITLE
docs(blog): polish N+1 insert-loop article to 9.0+ (5-reviewer panel)

### DIFF
--- a/apps/blog/content/articles/n-plus-1-insert-loop-api-performance.md
+++ b/apps/blog/content/articles/n-plus-1-insert-loop-api-performance.md
@@ -1,6 +1,6 @@
 ---
-title: "The Performance Protocol: Solving PostgreSQL N+1 Loops via Static Analysis"
-description: "Eliminate API performance bottlenecks at the commit level. A case study on detecting and fixing architectural N+1 patterns programmatically."
+title: "One INSERT Loop Made Our CSV Import 500x Slower. One ESLint Rule Catches It Before It Ships."
+description: "A for-loop with an INSERT inside turned a 100ms bulk write into 50 seconds — 500x slower at 1,000 rows. pg/no-batch-insert-loop (CWE-1049) catches the N+1 pattern in CI, before it ships."
 slug: "n-plus-1-insert-loop-api-performance"
 canonical_url: "https://ofriperetz.dev/articles/n-plus-1-insert-loop-api-performance"
 devto_url: "https://dev.to/ofri-peretz/the-n1-insert-loop-that-slowed-our-api-to-a-crawl-4534"
@@ -9,7 +9,7 @@ published_at: "2026-01-02T20:06:27Z"
 edited_at: "2026-01-11T10:21:30Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fn-plus-1-insert-loop-api-performance.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/n-plus-1-insert-loop-api-performance.png"
-reading_time_minutes: 2
+reading_time_minutes: 6
 tags:
   - "eslint"
   - "postgres"
@@ -99,18 +99,19 @@ npm install --save-dev eslint-plugin-pg
 ### Use Recommended Config (All Rules)
 
 ```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
+// `configs` is a NAMED export; the default export is the plugin object.
+import { configs } from "eslint-plugin-pg";
+export default [configs.recommended];
 ```
 
 ### Enable Only This Rule
 
 ```javascript
-import pg from "eslint-plugin-pg";
+import pgPlugin from "eslint-plugin-pg"; // default export = the plugin object
 
 export default [
   {
-    plugins: { pg },
+    plugins: { pg: pgPlugin },
     rules: {
       "pg/no-batch-insert-loop": "error",
     },
@@ -130,13 +131,24 @@ src/import.ts
 
 ## Detection Patterns
 
-The [`pg/no-batch-insert-loop`](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-batch-insert-loop) rule catches:
+For a **literal** query string, the rule's fast path flags `INSERT` and
+`UPDATE` queries inside a loop:
 
-- `query('INSERT...')` inside `for`, `for...of`, `for...in` loops
-- `query('INSERT...')` inside `while` and `do...while` loops
-- `query('INSERT...')` inside `forEach`, `map`, `reduce`, `filter` callbacks
-- `query('UPDATE...')` inside any loop construct
-- `query('DELETE...')` inside any loop construct
+- inside `for`, `for...of`, `for...in`, `while`, `do...while`
+- inside `forEach`, `map`, `reduce`, `filter` callbacks
+
+For a **non-literal** query — a template literal or a variable — the rule can't
+read the SQL verb, so it flags the query-in-loop regardless. That's how a
+`DELETE`-in-loop is caught:
+
+```js
+// flagged: non-literal query in a loop (any verb)
+for (const id of ids) await pool.query(`DELETE FROM users WHERE id = ${id}`);
+```
+
+A _literal_ `query("DELETE ...")` or `query("SELECT ...")` in a loop is
+intentionally skipped by the fast path — keeping the rule focused on the
+write-amplifying `INSERT`/`UPDATE` shape.
 
 ## Other Bulk Patterns
 
@@ -161,40 +173,42 @@ await pool.query(
 await pool.query("DELETE FROM users WHERE id = ANY($1)", [userIds]);
 ```
 
-## Quick Install
+## Compatibility
 
-```bash
-npm install --save-dev eslint-plugin-pg
-```
+| Surface              | Support                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun — plain dev dependency                                                              |
+| **Node**             | `>= 18.0.0`                                                                                              |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                                           |
+| **`pg` driver**      | peer `^6 \|\| ^7 \|\| ^8`; the rule is AST-based and lints regardless of installed version               |
+| **Module system**    | CommonJS — loads from both `eslint.config.js` and `eslint.config.mjs`                                    |
+| **Oxlint**           | Loads under Oxlint's JS-plugin runner via the `interlace-pg` port, with ESLint↔Oxlint parity gated in CI |
 
-```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
-```
+## What it does — and doesn't — see
 
-Turn 50-second imports into 100ms operations.
+`no-batch-insert-loop` flags a `query()` for a literal `INSERT`/`UPDATE` — or an
+interpolated query of any verb — inside a loop or array-iterator callback. It's a heuristic for the N+1 _shape_,
+not a runtime profiler — it can't measure your actual latency, and a loop that
+genuinely runs once isn't a real N+1. It catches the pattern that becomes one at
+scale, before it ships. (It's one of 13 rules in `eslint-plugin-pg`; the
+[pg getting-started](https://ofriperetz.dev/articles/getting-started-eslint-plugin-pg)
+covers the rest — SQL injection, `search_path` hijacking, connection leaks.)
 
 ---
 
-📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
-📖 [Rule docs: pg/no-batch-insert-loop](https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-pg/docs/rules/no-batch-insert-loop.md)
+- 📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
+- 📖 [Rule docs: pg/no-batch-insert-loop](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-batch-insert-loop)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-pg)
 
 ::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
-⭐ Star on GitHub
+⭐ Star on GitHub if a loop has ever turned your bulk import into a timeout.
 ::
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack. `eslint-plugin-pg` is its
+node-postgres layer.
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
-
----
-
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary
Polishes the N+1 insert-loop performance article (panel **4.5**; body already converts — 1 reaction, 3 comments) to **≥9.0 every lens** (Security 9.4, Growth 9.4, Compatibility 9.4, Reproducibility 9.4, Structure 9.2).

- Title off the "The Performance Protocol" flop → "One INSERT Loop Made Our CSV Import 500x Slower. One ESLint Rule Catches It Before It Ships."
- Fixed config import (named `import { configs }`; default-import `.configs` would crash); single-rule snippet uses `plugins: { pg: pgPlugin }`.
- **Corrected Detection Patterns** to match source: the literal fast-path flags `INSERT`/`UPDATE` only; a literal `DELETE`/`SELECT` is skipped, a non-literal query in a loop is flagged regardless of verb (old copy wrongly claimed literal DELETE-in-loop is caught).
- Byte-accurate sample (PERFORMANCE bolt + `CWE-1049 | … | HIGH`, no OWASP/CVSS — CWE-1049 isn't in the enrichment map).
- Removed "330 rules/100%" footer; added Compatibility + a cross-link to the pg getting-started. Preserved the converting narrative.

## Test plan
- [x] Prettier; named configs; 330-footer gone; sample byte-exact; Detection Patterns matches source.
- [x] 5-reviewer panel ≥9.0 (min 9.2).
- [ ] CI build-test-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)