### PR TITLE
docs(blog): rewrite OWASP-LLM mapping article to 9.0+ (5-reviewer panel)

### DIFF
--- a/apps/blog/content/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.md
+++ b/apps/blog/content/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.md
@@ -1,6 +1,6 @@
 ---
-title: "The OWASP LLM Protocol: 100% Automated Coverage for Vercel AI"
-description: "A complete mapping of OWASP LLM Top 10 to static analysis rules. The engineering standard for governance in the Vercel AI ecosystem."
+title: "Your Vercel AI SDK App vs the OWASP LLM Top 10: 8 Categories ESLint Catches in CI — and 2 It Honestly Can't."
+description: "A real mapping of the OWASP LLM Top 10 (2025) to eslint-plugin-vercel-ai-security: which categories a CWE-tagged rule genuinely catches in source, and which two (supply chain, model poisoning) live outside static analysis."
 slug: "100-owasp-llm-top-10-coverage-for-vercel-ai-sdk"
 canonical_url: "https://ofriperetz.dev/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk"
 devto_url: "https://dev.to/ofri-peretz/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk-1bom"
@@ -9,15 +9,12 @@ published_at: "2025-12-19T06:00:22Z"
 edited_at: "2026-02-05T05:33:09Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2F100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.jpg"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.jpg"
-reading_time_minutes: 4
+reading_time_minutes: 8
 tags:
   - "eslint"
   - "ai"
   - "security"
   - "owasp"
-reactions: 0
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,100 +23,154 @@ author:
 series: null
 ---
 
-**Governance for AI agents is the new frontier for CTOs. Here is the engineering standard for mapping the Vercel AI SDK to the OWASP LLM Top 10 through 100% automated static analysis rules.**
+"How do you address the OWASP LLM Top 10?" is now a question on enterprise
+security questionnaires. The honest answer for a Vercel AI SDK app is more
+useful than a "100% covered" checkbox — because **static analysis genuinely
+catches 8 of the 10 categories at the call site, and two of them it can't touch
+at all.** Knowing which is which is the difference between a real control and a
+compliance theater slide.
 
-The OWASP LLM Top 10 2025 is here. And your **Vercel AI SDK** application probably violates half of it.
+`eslint-plugin-vercel-ai-security` is SDK-aware (it understands `generateText`,
+`streamText`, `tool()`), and maps a CWE-tagged rule to the categories that are
+_source patterns_. Here's the real matrix.
 
-I know because I built a plugin to check. **One ESLint config. Full OWASP coverage. 60 seconds to install.**
+---
 
-> **This plugin is designed specifically for the Vercel AI SDK.** It understands `generateText`, `streamText`, `tool()`, and other SDK functions—not just pattern-matching on strings.
+## The 8 categories a rule genuinely catches
 
-## The 10 Categories (And How to Automate Them)
+| OWASP LLM (2025)                           | What it is                           | Rule                                                                    | CWE                         |
+| ------------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------- | --------------------------- |
+| **LLM01** Prompt Injection                 | untrusted input reaches the model    | `require-validated-prompt`, `no-dynamic-system-prompt`                  | CWE-74                      |
+| **LLM02** Sensitive Information Disclosure | secrets/PII sent to the LLM          | `no-sensitive-in-prompt`                                                | CWE-200                     |
+| **LLM05** Improper Output Handling         | model output → eval/SQL/innerHTML    | `no-unsafe-output-handling`                                             | CWE-94                      |
+| **LLM06** Excessive Agency                 | tools act with no confirmation/limit | `require-tool-confirmation`, `require-max-steps`, `require-tool-schema` | CWE-862                     |
+| **LLM07** System Prompt Leakage            | system prompt exposed in a response  | `no-system-prompt-leak`                                                 | CWE-200                     |
+| **LLM08** Vector & Embedding Weaknesses    | unvalidated RAG / embeddings         | `require-rag-content-validation`, `require-embedding-validation`        | CWE-74 / CWE-20             |
+| **LLM09** Misinformation                   | output shown to users unvalidated    | `require-output-validation`, `require-output-filtering`                 | CWE-707                     |
+| **LLM10** Unbounded Consumption            | token/step/time exhaustion           | `require-max-tokens`, `require-max-steps`, `require-request-timeout`    | CWE-770 / CWE-834 / CWE-400 |
 
-| #                                                                                    | OWASP Category                   | What It Means                      | ESLint Rule                                                                                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------ | -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [LLM01](https://genai.owasp.org/llmrisk/llm01-prompt-injection/)                     | Prompt Injection                 | User input manipulates AI behavior | [`require-validated-prompt`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-validated-prompt)                                                                                                            |
-| [LLM02](https://genai.owasp.org/llmrisk/llm022025-sensitive-information-disclosure/) | Sensitive Information Disclosure | Secrets/PII leaked to LLM          | [`no-sensitive-in-prompt`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/no-sensitive-in-prompt)                                                                                                                |
-| [LLM03](https://genai.owasp.org/llmrisk/llm032025-supply-chain/)                     | Supply Chain Vulnerabilities     | Compromised models/libraries       | [`no-training-data-exposure`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/no-training-data-exposure)                                                                                                          |
-| [LLM04](https://genai.owasp.org/llmrisk/llm042025-data-and-model-poisoning/)         | Data and Model Poisoning         | Malicious data in fine-tuning      | [`require-request-timeout`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-request-timeout)                                                                                                              |
-| [LLM05](https://genai.owasp.org/llmrisk/llm052025-improper-output-handling/)         | Improper Output Handling         | AI output executed as code         | [`no-unsafe-output-handling`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/no-unsafe-output-handling)                                                                                                          |
-| [LLM06](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)                 | Excessive Agency                 | AI invokes tools without consent   | [`require-tool-confirmation`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-tool-confirmation)                                                                                                          |
-| [LLM07](https://genai.owasp.org/llmrisk/llm072025-system-prompt-leakage/)            | System Prompt Leakage            | AI reveals system instructions     | [`no-system-prompt-leak`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/no-system-prompt-leak)                                                                                                                  |
-| [LLM08](https://genai.owasp.org/llmrisk/llm082025-vector-and-embedding-weaknesses/)  | Vector and Embedding Weaknesses  | Malicious embeddings in RAG        | [`require-embedding-validation`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-embedding-validation)                                                                                                    |
-| [LLM09](https://genai.owasp.org/llmrisk/llm092025-misinformation/)                   | Misinformation                   | AI output displayed without checks | [`require-output-validation`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-output-validation)                                                                                                          |
-| [LLM10](https://genai.owasp.org/llmrisk/llm102025-unbounded-consumption/)            | Unbounded Consumption            | Token/step exhaustion              | [`require-max-tokens`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-max-tokens), [`require-max-steps`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-max-steps) |
+Each finding carries the CWE and the fix. (Note: the inline `OWASP:` tag in a
+finding is the classic web-AppSec category the CWE rolls up to — e.g. CWE-74 →
+`A03 Injection` — not the LLM code; the **rule set** is organized around the LLM
+Top 10, the CWE is the precise anchor.)
 
-## Why This Matters
+---
 
-OWASP isn't just a checklist for security audits. It's becoming a **compliance requirement**.
+## The 2 categories static analysis can't honestly claim
 
-If you're building AI features for enterprise customers, they will ask: "How do you address the OWASP LLM Top 10?"
+This is where "100% coverage" decks lie. Two categories are **not** code
+patterns at a call site, so no source linter — this one included — genuinely
+covers them:
 
-Having an automated, auditable answer makes the difference between a closed deal and a 6-month security review.
+- **LLM03 Supply Chain** — a compromised model, a poisoned dependency, a
+  malicious LoRA adapter. That's a _dependency/model-provenance_ problem. Use
+  SBOM/lockfile integrity, model signing, and a dependency auditor —
+  `eslint-plugin-node-security`'s `require-dependency-integrity` / `lock-file`
+  touch the npm slice, but the model supply chain is out of scope for source
+  analysis.
+- **LLM04 Data & Model Poisoning** — malicious data entering training/fine-tuning
+  or a RAG store. That's a _data-pipeline_ control (provenance, validation at
+  ingest), not a `generateText` call shape. `no-training-data-exposure` flags
+  user data flowing _to_ a training endpoint (a privacy/egress concern), but it
+  does not detect poisoning _into_ the model.
 
-## Before & After
+Anyone selling you "automated 100% OWASP LLM coverage" is mapping a timeout rule
+to "model poisoning" and hoping you don't read the categories. You should.
 
-**Before** (silent vulnerability):
+---
 
-```typescript
-await generateText({
-  prompt: userInput, // No validation, no warning
+## What a finding looks like
+
+```text
+src/app/chat/route.ts
+  6:11  error  🔒 CWE-74 OWASP:A03-Injection CVSS:9 | User input "userMessage" passed directly to generateText prompt without validation | CRITICAL [SOC2,GDPR]
+              Fix: Validate input before use: generateText({ prompt: validateInput(userInput) })
+```
+
+```ts
+// ❌ LLM01 — untrusted input straight into the model
+const { text } = await generateText({ model, prompt: userMessage });
+
+// ✅ input passes a validation boundary
+const { text } = await generateText({
+  model,
+  prompt: validateInput(userMessage),
 });
 ```
 
-**After** (with the linter):
+(Honest caveat, same as the getting-started: the linter enforces that a
+validation _boundary exists_ — it can't prove your validator defeats injection.
+Nothing reliably does at the text layer. See the
+[vercel-ai-security deep-dive](https://ofriperetz.dev/articles/getting-started-eslint-plugin-vercel-ai-security)
+for the full mechanism of all 19 rules.)
+
+---
+
+## Install
 
 ```bash
-🔒 CWE-74 OWASP:LLM01 CVSS:9.0 | Unvalidated prompt input | CRITICAL
-   Fix: Validate/sanitize user input before use
+# npm
+npm install --save-dev eslint-plugin-vercel-ai-security
+# yarn / pnpm / bun: same, with that manager's --dev flag
 ```
 
-No more finding these in production.
-
-## The Implementation
-
-[eslint-plugin-vercel-ai-security](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) provides SDK-aware rules for the Vercel AI SDK. It's not pattern-matching on strings—it understands `generateText`, `streamText`, `tool()`, and other SDK functions.
-
-```javascript
-// eslint.config.js
-import vercelAISecurity from "eslint-plugin-vercel-ai-security";
+```js
+// eslint.config.js — `configs` is a NAMED export (default export is the plugin)
+import { configs } from "eslint-plugin-vercel-ai-security";
 
 export default [
-  vercelAISecurity.configs.recommended, // Balanced security
-  // vercelAISecurity.configs.strict,   // Maximum security
+  configs.recommended, // 7 errors + 7 warnings + 5 off
+  // configs.strict,   // 17 errors — production hardening
 ];
 ```
 
-### CI Integration
-
-Every PR now gets automatic OWASP validation:
-
 ```yaml
-# .github/workflows/security.yml
-- name: Lint AI Security
-  run: npx eslint 'src/**/*.ts' --max-warnings 0
+# CI — fail the PR on a new LLM-category finding
+- run: npx eslint . --max-warnings 0
 ```
 
-## The Punch Line
+---
 
-100% OWASP LLM coverage sounds impressive in a sales deck. But more importantly, it means your AI application is protected against the most common attack patterns.
+## Compatibility
 
-The plugin is free. The compliance is automatic. The alternative is manual pen-testing at $500/hour.
-
-Your call.
+| Surface              | Support                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                      |
+| **Node**             | `>= 18.0.0`                                                                               |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                            |
+| **Vercel AI SDK**    | optional peer — AST-based, lints whether or not `ai` is installed                         |
+| **Module system**    | CommonJS — `eslint.config.js` or `.mjs`                                                   |
+| **Oxlint**           | flagship rule (`no-unsafe-output-handling`) wired + parity-checked; full set ESLint-first |
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+## Why the honest matrix wins the security review
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
+A CTO's security reviewer has seen the "100%" slide. What closes the deal is a
+mapping they can _audit_: each covered category points to a named rule and a CWE
+they can verify, and the two uncovered categories come with the right control
+named (SBOM/model signing for LLM03, ingest validation for LLM04) instead of a
+hand-wave. "8 of 10, automated and CWE-tagged, plus a clear plan for the other
+two" is a stronger answer than a claim that collapses the moment someone opens
+the OWASP page.
 
 ---
 
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
+## Links
 
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+- 📦 [npm: eslint-plugin-vercel-ai-security](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security)
+- 📖 [Full rule docs](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules)
+- 🔐 [OWASP Top 10 for LLM Applications](https://genai.owasp.org/llm-top-10/)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-vercel-ai-security)
+
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if "we're 100% OWASP-covered" has ever made you suspicious.
+::
+
+---
+
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack.
+
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
Was 4.7 with a disprovable **'100% coverage'** claim + a wrong LLM04 mapping. Now **≥9.0 every lens** (Security 9.6, Compatibility 9.6, min 9.2). Reframed to the honest **8-of-10 matrix** — names the 2 categories (LLM03 supply chain, LLM04 poisoning) static analysis can't reach + their real controls; moved `require-request-timeout` to LLM10; byte-exact sample (`A03-Injection`, not the fabricated `LLM01`); named `{ configs }` import; removed 330/100% footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)