### PR TITLE
docs(blog): securing-ai-agents → 9.0+ (agency angle, verified SDK rules)

### DIFF
--- a/apps/blog/content/articles/securing-ai-agents-in-the-vercel-ai-sdk.md
+++ b/apps/blog/content/articles/securing-ai-agents-in-the-vercel-ai-sdk.md
@@ -1,6 +1,6 @@
 ---
-title: "The AI Security Protocol: Hardening Vercel AI SDK Agents"
-description: "The definitive engineering standard for AI-native security. Use automated static analysis to protect agents from LLM-specific vulnerabilities."
+title: "Your Vercel AI SDK Agent Can Delete Your Database. 5 ESLint Rules That Gate Every Tool Call."
+description: "An agent that hallucinates doesn't just say the wrong thing — it calls the wrong tool. Five CWE-tagged ESLint rules bound an AI agent's agency: tool confirmation, input schemas, step limits, error handling, and abort signals — caught at write-time."
 slug: "securing-ai-agents-in-the-vercel-ai-sdk"
 canonical_url: "https://ofriperetz.dev/articles/securing-ai-agents-in-the-vercel-ai-sdk"
 devto_url: "https://dev.to/ofri-peretz/securing-ai-agents-in-the-vercel-ai-sdk-485n"
@@ -9,7 +9,7 @@ published_at: "2025-12-20T00:03:08Z"
 edited_at: "2026-02-05T05:33:12Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fsecuring-ai-agents-in-the-vercel-ai-sdk.jpg"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/securing-ai-agents-in-the-vercel-ai-sdk.jpg"
-reading_time_minutes: 3
+reading_time_minutes: 6
 tags:
   - "eslint"
   - "ai"
@@ -23,157 +23,186 @@ author:
   username: "ofri-peretz"
   avatar: "https://media2.dev.to/dynamic/image/width=640,height=640,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Fuser%2Fprofile_image%2F3669992%2F50a1f256-472c-48a1-85e8-149459647ea7.png"
   twitter: "ofriperetzdev"
-series: null
+series: "Hardening AI Agents"
 ---
 
-2025 was the year of LLMs. 2026 is the year of **Agents**.
+An LLM that hallucinates is annoying. **An _agent_ that hallucinates calls the
+wrong tool** — and if that tool is `deleteUser`, the hallucination is a deleted
+production row.
 
-Agents don't just answer questions—they take actions. They browse the web, execute code, query databases, and call APIs. This changes the security model completely.
+The moment you hand a model `tools`, you've granted it agency: it decides _which
+function to run and with what arguments_. The OWASP LLM Top 10 calls the failure
+mode **LLM06: Excessive Agency**. `eslint-plugin-vercel-ai-security` is SDK-aware
+(it understands `generateText`/`streamText` and tool definitions), so it can
+check, at write-time, that every tool call is gated. Five rules do it.
 
-An LLM that hallucinates is annoying. **An Agent that hallucinates can delete your production database.**
+---
 
-> **This guide is for developers using the Vercel AI SDK.** The linting rules understand `generateText`, `streamText`, `tool()`, and other SDK functions natively.
+## The unprotected agent
 
-## The OWASP Agentic Top 10 2026
-
-OWASP saw this coming. They're drafting a new category specifically for agentic systems:
-
-| #     | Category                      | The Risk                              |
-| ----- | ----------------------------- | ------------------------------------- |
-| ASI01 | Agent Confusion               | System prompt dynamically overwritten |
-| ASI02 | Insufficient Input Validation | Tool parameters not validated         |
-| ASI03 | Insecure Credentials          | API keys hardcoded in config          |
-| ASI04 | Sensitive Data in Output      | Tools leak secrets in responses       |
-| ASI05 | Unexpected Code Execution     | AI output executed as code            |
-| ASI07 | RAG Injection                 | Malicious docs inject instructions    |
-| ASI08 | Cascading Failures            | Errors propagate across agent steps   |
-| ASI09 | Trust Boundary Violations     | AI bypasses authorization             |
-| ASI10 | Insufficient Logging          | No audit trail for AI actions         |
-
-## Visual Example: The Problem
-
-The Vercel AI SDK makes building agents easy. Maybe too easy.
-
-### ❌ Before: Unprotected Agent
-
-```typescript
-// This code ships to production every day
+```ts
+// ships to production more often than you'd think
 const result = await generateText({
-  model: openai("gpt-4"),
+  model: openai("gpt-4o"),
   tools: {
-    deleteUser: tool({
+    deleteUser: {
       execute: async ({ userId }) => {
-        await db.users.delete(userId); // No confirmation, no validation
+        await db.users.delete(userId); // no confirmation, no schema, no step bound
       },
-    }),
+    },
   },
 });
 ```
 
-**What's wrong?**
+Four things are missing in this snippet (a fifth, the abort signal, applies only
+to streaming calls). The linter names three of them inline; the fourth it flags
+separately:
 
-- No human confirmation before destructive action
-- No parameter validation on `userId`
-- No `maxSteps` limit—agent can loop forever
-- No error boundaries for cascading failures
-
-### ✅ After: With ESLint Protection
-
-Install and run the linter:
-
-```bash
-npm install eslint-plugin-vercel-ai-security --save-dev
-npx eslint src/
+```text
+src/agent.ts
+  3:5  warning  ⚠️ CWE-862 OWASP:A01-Broken CVSS:7 | Tool "deleteUser" performs destructive operation "delete" without requiring confirmation. | HIGH [SOC2]
+              Fix: Add requiresConfirmation: true or implement confirmation logic in the tool
+  3:5  error    🔒 CWE-20 OWASP:A03-Injection CVSS:7.5 | Tool "deleteUser" is missing inputSchema. Unvalidated tool parameters can lead to injection attacks. | HIGH [SOC2]
+              Fix: Add inputSchema using Zod: tool({ inputSchema: z.object({ ... }), execute: ... })
+  2:18 warning  ⚠️ CWE-834 OWASP:A05-Security CVSS:6.5 | generateText with tools is missing maxSteps. Without a limit, tool calls can loop indefinitely. | MEDIUM [SOC2]
+              Fix: Add maxSteps option: generateText({ ..., maxSteps: 5 })
 ```
 
-**Immediate feedback on every issue:**
+(A fourth rule, `require-error-handling` (CWE-755), flags the un-`try/catch`'d
+call separately — an agent step that throws shouldn't cascade.)
 
-```bash
-🔒 CWE-862 OWASP:ASI09 CVSS:7.0 | Destructive tool without confirmation | HIGH
-   at src/agent.ts:5:5
-   Fix: Add human-in-the-loop confirmation before execution
+---
 
-🔒 CWE-20 OWASP:ASI02 CVSS:6.5 | Tool parameters not validated | MEDIUM
-   at src/agent.ts:6:7
-   Fix: Add Zod schema validation for tool parameters
+## The 5 rules that bound agency
 
-🔒 CWE-400 OWASP:ASI08 CVSS:5.0 | No maxSteps limit on agent | MEDIUM
-   at src/agent.ts:3:16
-   Fix: Add maxSteps option to prevent infinite loops
-```
+| Rule                                                                                                                                  | CWE     | What it forces                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------- |
+| [`require-tool-confirmation`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-tool-confirmation) | CWE-862 | a destructive tool (delete/transfer/execute…) must carry a confirmation gate     |
+| [`require-tool-schema`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-tool-schema)             | CWE-20  | every tool declares an `inputSchema` (Zod) — the model can't pass arbitrary args |
+| [`require-max-steps`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-max-steps)                 | CWE-834 | a tool-calling loop is bounded by `maxSteps` — no infinite agent loop            |
+| [`require-error-handling`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-error-handling)       | CWE-755 | the SDK call is wrapped in `try/catch` — a failed step doesn't cascade           |
+| [`require-abort-signal`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules/require-abort-signal)           | CWE-404 | streaming calls take an `abortSignal` — a user can cancel a runaway stream       |
 
-### ✅ Fixed Code
+These are the operational half of agent safety. The _input_ half — prompt
+injection, system-prompt leakage — is the
+[prompt-injection deep-dive](https://ofriperetz.dev/articles/vercel-ai-sdk-prompt-injection-vulnerability);
+the full OWASP LLM map (8 of 10, honestly) is
+[here](https://ofriperetz.dev/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk).
 
-```typescript
+> **One honest limitation.** `require-tool-confirmation` inspects tool **object
+> literals** declared inline in `tools: { … }`. If you wrap a tool in the
+> `tool()` helper or extract it to a variable, the rule currently treats it as
+> "may be handled elsewhere" and skips it — a documented false-negative. Gate
+> those manually. (`require-tool-schema` _does_ read inside `tool({ … })`.) The
+> hardened pattern below uses the inline form so every rule fires.
+
+---
+
+## The hardened agent
+
+```ts
 import { z } from "zod";
 
-const result = await generateText({
-  model: openai("gpt-4"),
-  maxSteps: 10, // ✅ Prevent infinite loops
-  tools: {
-    deleteUser: tool({
-      parameters: z.object({
-        userId: z.string().uuid(), // ✅ Validated input
-      }),
-      execute: async ({ userId }, { confirmDangerous }) => {
-        await confirmDangerous(); // ✅ Human-in-the-loop
-        await db.users.delete(userId);
+try {
+  const result = await generateText({
+    model: openai("gpt-4o"),
+    maxSteps: 5, // require-max-steps — bound the loop
+    tools: {
+      deleteUser: {
+        description: "Delete a user account",
+        inputSchema: z.object({ userId: z.string().uuid() }), // require-tool-schema
+        requiresConfirmation: true, // require-tool-confirmation
+        execute: async ({ userId }) => {
+          await db.users.delete(userId);
+        },
       },
-    }),
-  },
-});
+    },
+  });
+} catch (err) {
+  // require-error-handling — a failed step is contained, not cascaded
+  logger.error("agent step failed", { err });
+}
 ```
 
-**Result:** All warnings resolved. Agent is production-ready.
+`requiresConfirmation: true` is the flag the rule looks for; the actual
+human-in-the-loop gate (a UI prompt, an approval queue) is yours to wire — the
+linter enforces that the _decision point exists_, not that your implementation
+is correct.
 
-## Setup (60 Seconds)
+---
 
-```javascript
-// eslint.config.js
-import vercelAISecurity from "eslint-plugin-vercel-ai-security";
+## Install
+
+```bash
+# npm
+npm install --save-dev eslint-plugin-vercel-ai-security
+# yarn
+yarn add -D eslint-plugin-vercel-ai-security
+# pnpm
+pnpm add -D eslint-plugin-vercel-ai-security
+# bun
+bun add -d eslint-plugin-vercel-ai-security
+```
+
+```js
+// eslint.config.js — `configs` is a NAMED export (the default export is the plugin)
+import { configs } from "eslint-plugin-vercel-ai-security";
 
 export default [
-  vercelAISecurity.configs.strict, // Maximum security for agents
+  configs.recommended, // balanced
+  // configs.strict,   // maximum agency hardening for agent code
 ];
 ```
 
-**Strict mode enforces:**
+> Name the file `eslint.config.mjs` if your `package.json` isn't
+> `"type": "module"`. The plugin is CommonJS and loads either way.
 
-- ✅ Tool schema validation (Zod)
-- ✅ Human confirmation for destructive actions
-- ✅ `maxSteps` limits for multi-step workflows
-- ✅ Error handling for cascading failures
-
-## Coverage: 9/10 OWASP Agentic Categories
-
-[eslint-plugin-vercel-ai-security](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security) covers **9/10 OWASP Agentic categories**. ASI06 (Memory Corruption) is N/A for TypeScript.
-
-The plugin knows:
-
-- Which functions are Vercel AI SDK calls
-- Which tools perform destructive operations
-- Whether proper safeguards are in place
-
-## The Bottom Line
-
-AI agents are the most powerful—and most dangerous—software we've ever built.
-
-The difference between a helpful assistant and a liability is the guardrails you put in place.
-
-**Don't ship agents without them.**
+```yaml
+# CI — block the PR on a new ungated tool
+- run: npx eslint . --max-warnings 0
+```
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+## Compatibility
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
+| Surface              | Support                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                      |
+| **Node**             | `>= 18.0.0`                                                                               |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                            |
+| **Vercel AI SDK**    | optional peer — AST-based; lints whether or not `ai` is installed                         |
+| **Module system**    | CommonJS — `eslint.config.js` or `.mjs`                                                   |
+| **Oxlint**           | flagship rule (`no-unsafe-output-handling`) wired + parity-checked; full set ESLint-first |
 
 ---
 
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
+## Where this fits
 
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+This is the **agency** view of `eslint-plugin-vercel-ai-security` — the tool-call
+surface where a model stops talking and starts acting. The companion pieces:
+
+- [Prompt injection, in 1 of 3 places](https://ofriperetz.dev/articles/vercel-ai-sdk-prompt-injection-vulnerability) — the input surface
+- [The OWASP LLM Top 10, mapped honestly](https://ofriperetz.dev/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk) — 8 of 10, and the 2 it can't
+- [All 19 rules, end to end](https://ofriperetz.dev/articles/getting-started-eslint-plugin-vercel-ai-security) — the full plugin
+
+---
+
+## Links
+
+- 📦 [npm: eslint-plugin-vercel-ai-security](https://www.npmjs.com/package/eslint-plugin-vercel-ai-security)
+- 📖 [Full rule docs (per-rule CWE + examples)](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security/rules)
+- 🔐 [OWASP LLM06: Excessive Agency](https://genai.owasp.org/llmrisk/llm062025-excessive-agency/)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-vercel-ai-security)
+
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if a `deleteUser` tool is one hallucination away from running in your app.
+::
+
+---
+
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack.
+
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

Near-total rewrite of the AI-agents article (was 4.9 — invented-SDK offender).

- **Removed the invented SDK signature** — `confirmDangerous()` execute-callback (not in the SDK; real options are `{toolCallId,messages,abortSignal}`) and `parameters: z.object` (the rule detects **`inputSchema`**).
- **Removed fabrications** — the speculative "OWASP Agentic Top 10 / ASI01–ASI10" taxonomy + ASI sample tokens (the formatter emits `A0x-Word`, never ASI), the "9/10 Agentic / 100% / 330-rules" overclaims, the `.configs` default-import (crashes), the ©/duplicate-bio cruft.
- **Reframed to the distinct agency / tool-call angle** (OWASP LLM06 Excessive Agency), cross-linked to the prompt-injection + OWASP-LLM companions so it doesn't overlap.
- **Five rules verified against source** with byte-exact `formatLLMMessage` samples (compliance `[SOC2]`, confirmed by running the built dist formatter) + the honest `tool()`-helper false-negative note + `{ configs }` named import.

## Test plan

- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.5**, Structure **9.3**, Compatibility **9.4**, Reproducibility **9.5**.
- [x] Compliance brackets verified against the built dist formatter (`[SOC2]` on all three — the `??` short-circuits explicit compliance over CWE-map enrichment).
- [x] Hardened example confirmed to fire/pass all five rules (inline object form so `require-tool-confirmation` triggers).

## After merge

dev.to auto-updates via `devto_id 3116469`. Site page deploys in the next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)