### PR TITLE
docs(blog): security interview cheat-sheet → 9.0+ (concept→rule map)

### DIFF
--- a/apps/blog/content/articles/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.md
+++ b/apps/blog/content/articles/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.md
@@ -1,6 +1,6 @@
 ---
-title: "The Security Engineering Blueprint: A JavaScript Master Document"
-description: "The definitive engineering blueprint for high-stakes JavaScript security. 15 core architectural concepts required for senior security engineering roles."
+title: "13 Security Questions Every JavaScript Interview Asks — and the ESLint Rule That Answers Each in CI"
+description: "The 13 security concepts that come up in senior JavaScript/Node interviews — SQLi, XSS, CSRF, JWT, prototype pollution, ReDoS, timing attacks — each with the bad-vs-good code, the CWE, and the exact ESLint rule that enforces it automatically."
 slug: "the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn"
 canonical_url: "https://ofriperetz.dev/articles/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn"
 devto_url: "https://dev.to/ofri-peretz/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn"
@@ -9,7 +9,7 @@ published_at: "2025-12-31T06:10:16Z"
 edited_at: "2026-02-05T05:33:13Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fthe-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.png"
-reading_time_minutes: 4
+reading_time_minutes: 6
 tags:
   - "eslint"
   - "career"
@@ -26,199 +26,207 @@ author:
 series: null
 ---
 
-**Landing a Senior Security Engineering role requires mastering the architectural patterns that prevent breaches. Here is the engineering blueprint for high-stakes JavaScript security.**
+I've interviewed 50+ backend and full-stack engineers. Security questions show
+up in almost every loop now — even for roles that aren't labeled "security."
+Here are the **13 questions** that come up the most, each with the answer in one
+breath, the bad-vs-good code, the CWE, and — the part most cheat-sheets skip —
+**the ESLint rule that enforces it so you never ship the bad version.**
 
-As an Engineering Manager, I've interviewed 50+ full-stack and backend candidates. Security questions are part of almost every technical interview—even for roles that aren't explicitly "security." Here are the 15 concepts that separate the prepared from the panicked.
-
-## The Fundamentals (Asked 90% of the time)
-
-### 1. "What is SQL Injection and how do you prevent it?"
-
-```javascript
-// ❌ Vulnerable
-db.query(`SELECT * FROM users WHERE id = ${userId}`);
-
-// ✅ Safe
-db.query("SELECT * FROM users WHERE id = $1", [userId]);
-```
-
-**Key phrase**: "Parameterized queries separate data from code."
-
-### 2. "What is XSS and what are the three types?"
-
-- **Stored XSS**: Malicious script saved to database
-- **Reflected XSS**: Script in URL reflected back
-- **DOM XSS**: Script manipulates DOM directly
-
-```javascript
-// ❌ DOM XSS
-element.innerHTML = userInput;
-
-// ✅ Safe
-element.textContent = userInput;
-```
-
-### 3. "How do you store passwords securely?"
-
-```javascript
-// ❌ Never
-const hash = crypto.createHash("md5").update(password);
-
-// ✅ Always
-const hash = await bcrypt.hash(password, 12);
-```
-
-**Key phrases**: "bcrypt", "argon2", "salt", "work factor"
-
-## Intermediate (Asked 70% of the time)
-
-### 4. "What is CSRF and how do you prevent it?"
-
-**Cross-Site Request Forgery**: Attacker tricks authenticated user into performing actions.
-
-**Prevention**: Synchronizer tokens, SameSite cookies, origin validation.
-
-### 5. "Explain the Same-Origin Policy"
-
-Browsers block requests to different origins (scheme + host + port).
-
-**Bypass mechanisms**: CORS headers, JSONP (deprecated), postMessage.
-
-### 6. "What are timing attacks?"
-
-```javascript
-// ❌ Vulnerable (leaks information via timing)
-if (userToken === secretToken) {
-}
-
-// ✅ Safe (constant-time comparison)
-crypto.timingSafeEqual(Buffer.from(userToken), Buffer.from(secretToken));
-```
-
-### 7. "How do you handle JWTs securely?"
-
-- Always verify signature
-- Check expiration (`exp`)
-- Don't use `algorithm: 'none'`
-- Store in httpOnly cookies, not localStorage
-
-## Advanced (Asked 50% of the time)
-
-### 8. "What is prototype pollution?"
-
-```javascript
-// ❌ Vulnerable
-obj[key] = value; // If key = "__proto__", pollutes Object.prototype
-
-// ✅ Safe
-if (key !== "__proto__" && key !== "constructor") {
-  obj[key] = value;
-}
-```
-
-### 9. "Explain Content Security Policy"
-
-HTTP header that restricts what resources can load:
-
-```text
-Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-abc123'
-```
-
-### 10. "What is ReDoS?"
-
-Regular Expression Denial of Service:
-
-```javascript
-// ❌ Evil regex (catastrophic backtracking)
-const regex = /^(a+)+$/;
-regex.test("aaaaaaaaaaaaaaaaaaaaaaaaaaaa!"); // Hangs
-```
-
-## Architecture Questions (Asked 40% of the time)
-
-### 11. "How would you design a secure authentication system?"
-
-- Password hashing (bcrypt/argon2)- Rate limiting on login- Account lockout after failures
-- MFA option
-- Secure session management
-- Password reset via email (time-limited tokens)
-
-### 12. "What's your approach to secrets management?"
-
-- Environment variables (minimum)
-- Secrets managers (AWS Secrets Manager, Vault)
-- No secrets in code or git history
-- Rotation policies
-
-### 13. "How do you secure a REST API?"
-
-- Authentication (JWT, OAuth2)
-- Authorization (RBAC, ABAC)
-- Input validation
-- Rate limiting
-- HTTPS only
-- CORS configuration
-
-## The "How Do You Stay Current?" Question
-
-**Good answers**:
-
-- "I follow OWASP updates"
-- "I use automated security linting"
-- "I read CVE disclosures"
-- "I contribute to security tools"
-
-**Great answer**:
-"I enforce security automatically. My ESLint config includes security rules that catch 80% of common vulnerabilities before code review."
-
-## Quick Reference Card
-
-| Vulnerability  | Prevention            | CWE                                                        |
-| -------------- | --------------------- | ---------------------------------------------------------- |
-| SQL Injection  | Parameterized queries | [CWE-89](https://cwe.mitre.org/data/definitions/89.html)   |
-| XSS            | Output encoding       | [CWE-79](https://cwe.mitre.org/data/definitions/79.html)   |
-| CSRF           | Tokens + SameSite     | [CWE-352](https://cwe.mitre.org/data/definitions/352.html) |
-| Broken Auth    | MFA + secure sessions | [CWE-287](https://cwe.mitre.org/data/definitions/287.html) |
-| Sensitive Data | Encryption            | [CWE-311](https://cwe.mitre.org/data/definitions/311.html) |
-| Injection      | Input validation      | [CWE-20](https://cwe.mitre.org/data/definitions/20.html)   |
+The best answer to "how do you stay current?" isn't "I read CVEs." It's "I
+enforce these in CI." This is how.
 
 ---
 
-## Enforce It Automatically
+## The fundamentals (asked ~90% of the time)
 
-Each vulnerability category has a dedicated ESLint plugin:
+### 1. SQL Injection
 
-| Category      | Plugin                                                                                       | Rules |
-| ------------- | -------------------------------------------------------------------------------------------- | ----- |
-| SQL Injection | [`eslint-plugin-pg`](https://npmjs.com/package/eslint-plugin-pg)                             | 15    |
-| XSS/Browser   | [`eslint-plugin-browser-security`](https://npmjs.com/package/eslint-plugin-browser-security) | 52    |
-| Crypto/Timing | [`eslint-plugin-node-security`](https://npmjs.com/package/eslint-plugin-node-security)       | 31    |
-| JWT Security  | [`eslint-plugin-jwt`](https://npmjs.com/package/eslint-plugin-jwt)                           | 13    |
-| Auth/Secrets  | [`eslint-plugin-secure-coding`](https://npmjs.com/package/eslint-plugin-secure-coding)       | 26    |
+```javascript
+db.query(`SELECT * FROM users WHERE id = ${userId}`); // ❌
+db.query("SELECT * FROM users WHERE id = $1", [userId]); // ✅
+```
+
+**Say:** "Parameterized queries separate data from code." **CWE-89.** Enforced by
+`pg/no-unsafe-query`.
+
+### 2. XSS (and its three types)
+
+Stored (saved to the DB), reflected (echoed from the URL), and DOM (written by
+client JS). The browser-side fix is the same reflex:
+
+```javascript
+element.innerHTML = userInput; // ❌
+element.textContent = userInput; // ✅
+```
+
+**CWE-79.** Enforced by `browser-security/no-innerhtml`.
+
+### 3. Password storage
+
+```javascript
+crypto.createHash("md5").update(password); // ❌
+await bcrypt.hash(password, 12); // ✅
+```
+
+**Say:** "bcrypt or argon2, per-user salt, a work factor." **CWE-916.** The weak
+hash is caught by `node-security/no-weak-hash-algorithm`.
+
+---
+
+## Intermediate (asked ~70% of the time)
+
+### 4. CSRF
+
+Cross-Site Request Forgery rides an authenticated user's cookies to perform
+actions they didn't intend. **Prevention:** synchronizer tokens, `SameSite`
+cookies, origin checks. **CWE-352.** Enforced by
+`express-security/require-csrf-protection`.
+
+### 5. The Same-Origin Policy
+
+Browsers isolate by origin (scheme + host + port). The controlled relaxations are
+CORS, `postMessage`, and (legacy) JSONP — and an over-broad CORS policy
+re-opens everything (**CWE-942**). `browser-security/no-permissive-cors` catches
+the wildcard.
+
+### 6. Timing attacks
+
+```javascript
+if (userToken === secretToken) {
+} // ❌ leaks via comparison time
+crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b)); // ✅ constant-time
+```
+
+**CWE-208.** Enforced by `node-security/no-timing-unsafe-compare`.
+
+### 7. JWTs
+
+Verify the signature, check `exp`, never accept `algorithm: "none"`, and store in
+an `httpOnly` cookie — **not** `localStorage`. **CWE-347** for the `none` bypass
+(`jwt/no-algorithm-none`); the storage mistake is `browser-security/no-jwt-in-storage`.
+
+---
+
+## Advanced (asked ~50% of the time)
+
+### 8. Prototype pollution
+
+```javascript
+obj[key] = value; // ❌ key="__proto__" pollutes Object.prototype
+if (key !== "__proto__" && key !== "constructor" && key !== "prototype")
+  obj[key] = value; // ✅
+```
+
+**CWE-1321.** Caught by `secure-coding/detect-object-injection` (the rule's own
+finding tags CWE-915; CWE-1321 is the canonical JS-prototype-pollution entry).
+
+### 9. Content Security Policy
+
+An HTTP header that restricts what can load: `default-src 'self'; script-src 'self' 'nonce-…'`.
+**CWE-693.** `browser-security/require-csp-headers` flags its absence;
+`no-unsafe-inline-csp` flags the `'unsafe-inline'` that defeats it.
+
+### 10. ReDoS
+
+```javascript
+/^(a+)+$/.test("aaaaaaaaaaaaaaaaaaaaaaaa!"); // ❌ catastrophic backtracking
+```
+
+Regular-Expression Denial of Service. Caught by
+`secure-coding/no-redos-vulnerable-regex`.
+
+---
+
+## Architecture (asked ~40% of the time)
+
+### 11. Designing secure authentication
+
+- Password hashing (bcrypt/argon2)
+- Rate limiting on login + account lockout after repeated failures
+- MFA
+- Secure session management
+- Password reset via time-limited tokens
+
+Most of this is architectural, but the enforceable slice is real: the rate-limit
+gap on the login route is `express-security/require-rate-limiting` (**CWE-307**).
+
+### 12. Secrets management
+
+Environment variables at minimum; a secrets manager (Vault, AWS Secrets Manager)
+in production; nothing in code or git history; a rotation policy. **CWE-798** —
+`secure-coding/no-hardcoded-credentials` is the backstop for the last one.
+
+### 13. Securing a REST API
+
+AuthN (JWT/OAuth2), AuthZ (RBAC/ABAC), input validation, rate limiting, HTTPS
+only, and a tight CORS policy — `express-security/require-helmet` plus the rate
+and CORS rules above cover the configuration half.
+
+---
+
+## Quick-reference: the six with a one-line code fix
+
+| Vulnerability      | Prevention            | CWE                                                          | Enforced by                                |
+| ------------------ | --------------------- | ------------------------------------------------------------ | ------------------------------------------ |
+| SQL Injection      | Parameterized queries | [CWE-89](https://cwe.mitre.org/data/definitions/89.html)     | `pg/no-unsafe-query`                       |
+| XSS                | Output encoding       | [CWE-79](https://cwe.mitre.org/data/definitions/79.html)     | `browser-security/no-innerhtml`            |
+| CSRF               | Tokens + SameSite     | [CWE-352](https://cwe.mitre.org/data/definitions/352.html)   | `express-security/require-csrf-protection` |
+| Weak password hash | bcrypt / argon2       | [CWE-916](https://cwe.mitre.org/data/definitions/916.html)   | `node-security/no-weak-hash-algorithm`     |
+| Prototype poll.    | Key allow-list        | [CWE-1321](https://cwe.mitre.org/data/definitions/1321.html) | `secure-coding/detect-object-injection`    |
+| ReDoS              | Linear-time regex     | [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html) | `secure-coding/no-redos-vulnerable-regex`  |
+
+---
+
+## The "great" answer: enforce it, don't memorize it
+
+Reciting these in an interview proves you know them. Wiring them into CI proves
+you'll never ship them. Each concept above maps to a rule in a domain-specific
+[Interlace](https://eslint.interlace.tools) plugin — install the layers your
+stack uses and the bad version gets flagged (run with `--max-warnings 0` in CI so
+every finding blocks, not just the `error`-tier ones):
 
 ```bash
-# Install the full security suite
-npm install --save-dev eslint-plugin-secure-coding
-npm install --save-dev eslint-plugin-node-security
-npm install --save-dev eslint-plugin-jwt
-npm install --save-dev eslint-plugin-pg
-npm install --save-dev eslint-plugin-browser-security
+# npm (yarn/pnpm/bun: same packages, that manager's -D/--dev flag)
+npm install --save-dev eslint-plugin-secure-coding eslint-plugin-node-security \
+  eslint-plugin-jwt eslint-plugin-pg eslint-plugin-browser-security eslint-plugin-express-security
 ```
 
-**[⭐ Star the Interlace ESLint Ecosystem](https://github.com/ofri-peretz/eslint)**
+```js
+// eslint.config.mjs — `configs` is a NAMED export (default export is the plugin)
+import { configs as secureCoding } from "eslint-plugin-secure-coding";
+import { configs as nodeSecurity } from "eslint-plugin-node-security";
+
+export default [secureCoding.recommended, nodeSecurity.recommended];
+```
+
+| Surface              | Support                                                    |
+| -------------------- | ---------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                       |
+| **Node**             | `>= 18.0.0`                                                |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config             |
+| **Module system**    | CommonJS — `eslint.config.js` or `.mjs`                    |
+| **Oxlint**           | flagship rules wired via the `interlace-*` ports, CI-gated |
+
+For the full OWASP picture (and the two categories static analysis honestly
+can't reach), see
+[the OWASP Top 10 mapping](https://ofriperetz.dev/articles/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules).
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+## Links
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
+- 📦 [eslint-plugin-secure-coding](https://www.npmjs.com/package/eslint-plugin-secure-coding) · [node-security](https://www.npmjs.com/package/eslint-plugin-node-security) · [jwt](https://www.npmjs.com/package/eslint-plugin-jwt) · [pg](https://www.npmjs.com/package/eslint-plugin-pg) · [browser-security](https://www.npmjs.com/package/eslint-plugin-browser-security)
+- 📖 [Full rule docs (per-rule CWE)](https://eslint.interlace.tools)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint)
 
-© 2026 Ofri Peretz. All rights reserved.
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if you'd rather enforce this list than memorize it for the next interview.
+::
 
 ---
 
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack.
 
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

PROMOTE of the JS security interview cheat-sheet (was 4.9). The technical content was sound; the integrity problems were the framing and the counts.

- **Fixed the false count** — "15 concepts" → there are **13** (title + intro).
- **Killed the fabricated count-table** — pg "15"→13, browser "52"→45, node-security "31"→34, secure-coding "26"→27 were all wrong. Replaced with a **concept → real enforcing rule** map (every rule verified to exist in its plugin).
- **Dropped a misleading citation** — `secure-coding/no-missing-authentication` is deprecated and **excluded from `recommended`**, so it wouldn't fire from the copy-pasted config; replaced with the enforceable `require-rate-limiting`.
- Fixed a markdown bug (3 auth bullets mashed on one line), the "catches 80%" unverifiable stat, added per-concept CWEs + a Compatibility table + `{ configs }` named import + `.mjs` header + honest `--max-warnings 0` build-fail framing; removed the "330-rules/100%/©/duplicate-bio" cruft.

## Test plan

- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.4**, Structure **9.3**, Compatibility **9.4**, Reproducibility **9.2** — passed first round; post-pass accuracy fixes applied (deprecated-rule citation, CWE consistency, warn-vs-error framing).
- [x] Every cited rule verified against `packages/eslint-plugin-*/src/rules/`.

## After merge

dev.to auto-updates via `devto_id 3137519`. Site page deploys in the next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)