### PR TITLE
docs(blog): JWT alg:none exploit → 9.0+ (verified render, fixed broken CTA)

### DIFF
--- a/apps/blog/content/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.md
+++ b/apps/blog/content/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.md
@@ -1,6 +1,6 @@
 ---
-title: "Exploit Analysis: The JWT Algorithm 'none' Attack (And the Guard)"
-description: "A technical analysis of the most dangerous auth misconfiguration. How to engineering static analysis guards to eliminate 'none' exploits."
+title: "The JWT alg:none Attack: Change One Header Field, Forge an Admin Token. One ESLint Rule Blocks It."
+description: "alg:none tells a JWT verifier 'this token has no signature' — and a permissive verify call accepts the forgery. The header-swap walkthrough, why jsonwebtoken still ships the foot-gun, and the CWE-347 ESLint rule that fails the build on it."
 slug: "the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g"
 canonical_url: "https://ofriperetz.dev/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g"
 devto_url: "https://dev.to/ofri-peretz/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g"
@@ -9,15 +9,12 @@ published_at: "2025-12-31T05:53:24Z"
 edited_at: "2026-02-05T05:33:16Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fthe-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.png"
-reading_time_minutes: 4
+reading_time_minutes: 5
 tags:
   - "eslint"
   - "security"
   - "jwt"
   - "node"
-reactions: 1
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,166 +23,147 @@ author:
 series: null
 ---
 
-**A single line of configuration can forge a JWT. Here is the technical analysis of the 'none' algorithm attack, and the automated static analysis guard that eliminates this architectural risk.**
-
-JWT authentication is everywhere. It's also one of the most misconfigured security mechanisms.
-
-**One line of code can compromise everything.**
-
-## The Vulnerable Code
+`alg: "none"` is a JWT header value that means **"this token has no
+signature — don't verify one."** It exists for unsecured tokens. It is also a
+full authentication bypass the moment your verify call accepts it:
 
 ```javascript
-// ❌ This looks fine...
-const decoded = jwt.verify(token, secret, {
-  algorithms: ["HS256", "none"], // 💀 The vulnerability
-});
+// ❌ one entry in this list is a forged-token machine
+jwt.verify(token, secret, { algorithms: ["HS256", "none"] });
 ```
 
-## The Attack
+## The attack: change one header field
 
-```javascript
-// 1. Attacker takes a valid JWT:
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.
-eyJzdWIiOiIxMjM0NTYiLCJyb2xlIjoidXNlciJ9.
-signature_here
+A JWT is three base64url parts: `header.payload.signature`. The attacker takes
+any valid token and edits the **header** to claim no algorithm, rewrites the
+**payload** to whatever they want, and drops the signature entirely:
 
-// 2. Modifies the header to use "none" algorithm:
-eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.
-eyJzdWIiOiIxMjM0NTYiLCJyb2xlIjoiYWRtaW4ifQ.
-// No signature needed!
-
-// 3. Server accepts it because "none" is in algorithms list
-// Attacker is now admin
+```text
+# header  → {"alg":"none","typ":"JWT"}
+eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0
+# payload → {"sub":"123456","role":"admin"}
+.eyJzdWIiOiIxMjM0NTYiLCJyb2xlIjoiYWRtaW4ifQ
+# signature → (empty)
+.
 ```
 
-## Real CVEs
+No private key, no brute force. Because `"none"` is in your `algorithms` list,
+the verifier skips signature checking, reads `"role":"admin"`, and waves the
+attacker through. **CWE-347 — Improper Verification of Cryptographic Signature.**
 
-| CVE            | Library    | Impact                |
-| -------------- | ---------- | --------------------- |
-| CVE-2015-2951  | jwt-simple | Algorithm confusion   |
-| CVE-2016-10555 | jose2go    | None algorithm bypass |
-| CVE-2018-0114  | node-jose  | Key confusion         |
+## It's not theoretical
 
-## The Fix
+This is the 2015 disclosure (Tim McLean, _"Critical vulnerabilities in JSON Web
+Token libraries"_) that forced the whole ecosystem to harden. Modern
+`jsonwebtoken` won't accept `alg:none` **unless you explicitly allow it** — which
+is exactly the misconfiguration that still ships: someone adds `"none"` to the
+`algorithms` array to make a test pass, or to support a legacy unsigned token,
+and forgets it's there.
 
-```javascript
-// ✅ Explicitly whitelist algorithms
-const decoded = jwt.verify(token, secret, {
-  algorithms: ["HS256"], // Only what you use!
-});
-```
-
-## All JWT Vulnerabilities
-
-### 1. Algorithm None
+## The fix: pin the algorithms you actually use
 
 ```javascript
-// ❌ Dangerous
-jwt.verify(token, secret, { algorithms: ["none"] });
-
-// ✅ Safe
+// ✅ only the algorithm you sign with — "none" can never match
 jwt.verify(token, secret, { algorithms: ["HS256"] });
 ```
 
-### 2. Algorithm Confusion
+An explicit, minimal `algorithms` list is the whole defense: if `"none"` (and
+the keys you don't use) can't appear, the bypass can't happen.
 
-```javascript
-// ❌ Dangerous: RS256 token verified with symmetric secret
-jwt.verify(token, publicKey);
+## The rule: `no-algorithm-none` (CWE-347)
 
-// ✅ Safe: Explicit algorithm
-jwt.verify(token, publicKey, { algorithms: ["RS256"] });
-```
-
-### 3. Weak Secret
-
-```javascript
-// ❌ Dangerous: Brute-forceable
-jwt.sign(payload, "password123");
-
-// ✅ Safe: Strong secret
-jwt.sign(payload, process.env.JWT_SECRET); // 256+ bits
-```
-
-### 4. Missing Expiration
-
-```javascript
-// ❌ Dangerous: Token valid forever
-jwt.sign({ userId: 123 }, secret);
-
-// ✅ Safe: Short expiration
-jwt.sign({ userId: 123 }, secret, { expiresIn: "1h" });
-```
-
-### 5. Sensitive Payload
-
-```javascript
-// ❌ Dangerous: Password in token (tokens can be decoded!)
-jwt.sign({ userId: 123, password: "secret" }, key);
-
-// ✅ Safe: Only IDs
-jwt.sign({ userId: 123 }, key);
-```
-
-## ESLint Coverage
-
-```javascript
-// eslint.config.js
-import jwtPlugin from "eslint-plugin-jwt";
-
-export default [jwtPlugin.configs.recommended];
-```
-
-### 13 JWT Rules
-
-| Rule                                                                                                                       | CWE                                                        | What it catches          |
-| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------ |
-| [`no-algorithm-none`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-algorithm-none)                     | [CWE-347](https://cwe.mitre.org/data/definitions/347.html) | Algorithm "none" allowed |
-| [`no-algorithm-confusion`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-algorithm-confusion)           | [CWE-327](https://cwe.mitre.org/data/definitions/327.html) | RS/HS confusion attacks  |
-| [`no-weak-secret`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-weak-secret)                           | [CWE-326](https://cwe.mitre.org/data/definitions/326.html) | Brute-forceable secrets  |
-| [`no-hardcoded-secret`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-hardcoded-secret)                 | [CWE-798](https://cwe.mitre.org/data/definitions/798.html) | Secrets in code          |
-| [`no-sensitive-payload`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-sensitive-payload)               | [CWE-312](https://cwe.mitre.org/data/definitions/312.html) | PII in tokens            |
-| [`require-expiration`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-expiration)                   | [CWE-613](https://cwe.mitre.org/data/definitions/613.html) | Missing exp claim        |
-| [`require-algorithm-whitelist`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-algorithm-whitelist) | [CWE-327](https://cwe.mitre.org/data/definitions/327.html) | No explicit algorithms   |
-| [`require-issuer-validation`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-issuer-validation)     | [CWE-345](https://cwe.mitre.org/data/definitions/345.html) | Missing iss check        |
-| [`require-audience-validation`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-audience-validation) | [CWE-345](https://cwe.mitre.org/data/definitions/345.html) | Missing aud check        |
-| [`no-decode-without-verify`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-decode-without-verify)       | [CWE-347](https://cwe.mitre.org/data/definitions/347.html) | jwt.decode() misuse      |
-| [`require-issued-at`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-issued-at)                     | [CWE-613](https://cwe.mitre.org/data/definitions/613.html) | Missing iat claim        |
-| [`require-max-age`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/require-max-age)                         | [CWE-613](https://cwe.mitre.org/data/definitions/613.html) | No maxAge in verify      |
-| [`no-timestamp-manipulation`](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-timestamp-manipulation)     | [CWE-345](https://cwe.mitre.org/data/definitions/345.html) | Clock skew exploits      |
-
-## Error Messages
+You won't catch a stray `"none"` in a 200-file codebase by eye. The linter fails
+the build on it:
 
 ```bash
-src/auth.ts
-  15:3  error  🔒 CWE-347 CVSS:9.8 | JWT algorithm 'none' is allowed
-               Risk: Attackers can forge tokens without a signature
-               Fix: Remove 'none' from algorithms: ['HS256']
+npm install --save-dev eslint-plugin-jwt
 ```
 
-## Quick Install
+```js
+// eslint.config.mjs — `configs` is a NAMED export (default export is the plugin)
+import { configs } from "eslint-plugin-jwt";
 
-::dev-to-cta{url="<https://npmjs.com/package/eslint-plugin-jwt> in 60 seconds. 13 rules. Full JWT security. Zero false positives.\*\*
+export default [configs.recommended];
+```
+
+```text
+src/auth.ts
+  15:3  error  🔒 CWE-347 | Using alg:"none" bypasses signature verification, allowing token forgery | CRITICAL
+              Fix: Remove "none" and use RS256, ES256, or other secure algorithms
+```
+
+(The ESLint CLI also appends the rule's doc URL to the `Fix:` line; it's trimmed
+here for width.) The rule flags `"none"` anywhere in an `algorithms` array —
+case-insensitively, and whether it's the only entry or buried in a list like the
+one above.
+
+## The cousin: algorithm confusion
+
+`alg:none` has a subtler relative. If you verify with **no** pinned algorithm and
+hand the library your RS256 **public** key, an attacker re-signs a token with
+that public key using **HS256** — and the library, treating the public key as an
+HMAC secret, accepts it:
+
+```javascript
+jwt.verify(token, publicKey); // ❌ no algorithms list → RS256 verified as HS256
+jwt.verify(token, publicKey, { algorithms: ["RS256"] }); // ✅ pinned
+```
+
+Same root cause, same fix: **always pass an explicit `algorithms` list.**
+`no-algorithm-confusion` and `require-algorithm-whitelist` enforce it. Those —
+plus secret strength, claim validation (`exp`/`iss`/`aud`), and the
+`jwt.decode()` trap — are the other 12 rules, walked end to end in the
+[eslint-plugin-jwt getting-started](https://ofriperetz.dev/articles/getting-started-eslint-plugin-jwt).
 
 ---
 
-📦 [npm: eslint-plugin-jwt](https://www.npmjs.com/package/eslint-plugin-jwt)
-📖 [Rule: no-algorithm-none](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-jwt/docs/rules/no-algorithm-none.md)
+## Install
 
-**[⭐ Star on GitHub](https://github.com/ofri-peretz/eslint)**
+```bash
+# npm
+npm install --save-dev eslint-plugin-jwt
+# yarn
+yarn add -D eslint-plugin-jwt
+# pnpm
+pnpm add -D eslint-plugin-jwt
+# bun
+bun add -d eslint-plugin-jwt
+```
+
+```yaml
+# CI — block the PR on a re-introduced "none"
+- run: npx eslint . --max-warnings 0
+```
+
+## Compatibility
+
+| Surface              | Support                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                    |
+| **Node**             | `>= 18.0.0`                                                                             |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                          |
+| **JWT libraries**    | detects `jsonwebtoken` and `jose` call shapes (`sign`/`verify`/`decode`) — reads source |
+| **Module system**    | Plugin ships CommonJS; your config can be `eslint.config.js` or `.mjs`                  |
+| **Oxlint**           | Loads under Oxlint's JS-plugin runner via the `interlace-jwt` port, parity-gated in CI  |
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+## Links
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
+- 📦 [npm: eslint-plugin-jwt](https://www.npmjs.com/package/eslint-plugin-jwt)
+- 📖 [Rule docs: no-algorithm-none](https://eslint.interlace.tools/docs/security/plugin-jwt/rules/no-algorithm-none)
+- 📚 [The full 13-rule JWT walkthrough](https://ofriperetz.dev/articles/getting-started-eslint-plugin-jwt)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-jwt)
 
-© 2026 Ofri Peretz. All rights reserved.
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if a `verify` call in your codebase has ever listed `"none"`.
+::
 
 ---
 
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack. `eslint-plugin-jwt` is its
+JWT/auth layer.
 
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

Rewrite of the JWT `alg:none` exploit article (was 5.5, flagged for a dead-markup CTA).

- **Fixed the broken CTA** — the old `::dev-to-cta` block was malformed (unclosed, wrong URL, "zero false positives" overclaim) and rendered as dead markup.
- **Corrected the sample** to the verified render: `🔒 CWE-347 | Using alg:"none" bypasses signature verification, allowing token forgery | CRITICAL` (CWE-347 isn't in the CWE map → no CVSS/OWASP/compliance; the old `CVSS:9.8` + "Risk:" line were fabricated).
- **Dropped the 13-rule table** (it carried 8 wrong CWEs) — cross-linked the getting-started instead; replaced the unverified 3-row CVE table with the canonical 2015 Tim McLean disclosure reference.
- `{ configs }` named import (the old `jwtPlugin.configs` default-import crashes); added Compatibility; removed the "330/100%/©/duplicate-bio" cruft. Verified the Oxlint `interlace-jwt` port exists in `tools/oxlint-plugins/`.

## Test plan

- [x] 5-reviewer panel (gate ≥9.0): Growth **9.4**, Security **9.6**, Structure **9.4**, Compatibility **9.5**, Reproducibility **9.6**.
- [x] no-algorithm-none render + base64 walkthrough verified against source.

## After merge

dev.to auto-updates via `devto_id 3137489`. Site page deploys in the next batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)