### PR TITLE
docs(blog): BEGIN-on-pool race conditions → 9.0+ (verified rule coverage)

### DIFF
--- a/apps/blog/content/articles/transaction-race-conditions-begin-on-pool.md
+++ b/apps/blog/content/articles/transaction-race-conditions-begin-on-pool.md
@@ -1,6 +1,6 @@
 ---
-title: "Post-Mortem: Race Conditions in PostgreSQL Pools (And the Guard)"
-description: "A technical post-mortem on transaction corruption in Node.js. Learn the static analysis standard for safe transaction management on pooled clients."
+title: "BEGIN on a Postgres Pool Scatters Your Transaction Across Connections. One ESLint Rule Stops It."
+description: "pool.query('BEGIN') runs on a different pooled client than the UPDATE that follows it — so your 'transaction' isn't atomic and corrupts data under load. The race condition (CWE-362), the dedicated-client fix, and the pg ESLint rule that catches every BEGIN/COMMIT on a pool."
 slug: "transaction-race-conditions-begin-on-pool"
 canonical_url: "https://ofriperetz.dev/articles/transaction-race-conditions-begin-on-pool"
 devto_url: "https://dev.to/ofri-peretz/transaction-race-conditions-why-begin-on-pool-breaks-everything-117h"
@@ -9,15 +9,12 @@ published_at: "2025-12-31T21:38:13Z"
 edited_at: "2026-01-11T10:21:47Z"
 cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Ftransaction-race-conditions-begin-on-pool.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/transaction-race-conditions-begin-on-pool.png"
-reading_time_minutes: 2
+reading_time_minutes: 5
 tags:
   - "eslint"
   - "postgres"
   - "node"
   - "database"
-reactions: 0
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,16 +23,11 @@ author:
 series: "Postgres Security Protocol"
 ---
 
-**Managing transactions on a shared connection pool is an architectural minefield. Here is the technical post-mortem on race conditions, and the static analysis standard for safe PostgreSQL transaction management.**
-
-This code looks correct. It passes all tests. It works in development.
-
-In production with 100 concurrent users, it corrupts data.
-
-## The Bug
+This passes every test and works perfectly in development. Under 100 concurrent
+users in production, it silently corrupts account balances:
 
 ```javascript
-// ❌ Dangerous: Transaction on pool
+// ❌ a "transaction" on the pool
 async function transferFunds(from, to, amount) {
   await pool.query("BEGIN");
   await pool.query("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [
@@ -50,22 +42,29 @@ async function transferFunds(from, to, amount) {
 }
 ```
 
-## Why It Fails
+## Why it corrupts data
 
-A PostgreSQL **pool** is a set of client connections. Each `pool.query()` can use a **different client**.
+A `Pool` is a _set_ of connections. Each `pool.query()` checks out **whatever
+client is free at that moment** — so the four statements above can run on four
+different connections:
 
-```sql
-Request 1: pool.query('BEGIN')     → Client A
-Request 1: pool.query('UPDATE...')  → Client B (different!)
-Request 2: pool.query('BEGIN')     → Client A (reused!)
+```text
+pool.query('BEGIN')      → Client A   (a transaction opens on A)
+pool.query('UPDATE …')   → Client B   (runs outside A's transaction!)
+pool.query('UPDATE …')   → Client C
+pool.query('COMMIT')     → Client A   (commits an empty transaction)
 ```
 
-Your transaction is now spread across multiple clients. Your data is now inconsistent.
+The `BEGIN` and `COMMIT` land on a client that never saw the `UPDATE`s. The
+updates run as autocommitted statements on other clients — no atomicity, no
+rollback, no isolation. Two concurrent transfers interleave and the balance is
+wrong. This is a textbook **race condition (CWE-362)** — and it's invisible until
+concurrency is high enough to scatter the statements.
 
-## The Correct Pattern
+## The fix: one client for the whole transaction
 
 ```javascript
-// ✅ Safe: Get dedicated client, use it for entire transaction
+// ✅ BEGIN, every query, and COMMIT on the SAME client
 async function transferFunds(from, to, amount) {
   const client = await pool.connect();
   try {
@@ -83,48 +82,53 @@ async function transferFunds(from, to, amount) {
     await client.query("ROLLBACK");
     throw e;
   } finally {
-    client.release();
+    client.release(); // always return the client to the pool
   }
 }
 ```
 
-**Same client** for `BEGIN`, all queries, and `COMMIT`. Transaction integrity guaranteed.
+A checked-out client is a single connection held for the duration — `BEGIN`,
+every `UPDATE`, and `COMMIT` execute on it, so the transaction is atomic. (And
+release it in `finally`, or you trade a race condition for a [connection
+leak](https://ofriperetz.dev/articles/database-connection-leak-production-outage).)
 
-## The Rule
+## The rule: `no-transaction-on-pool`
 
-```javascript
-// ❌ pool.query('BEGIN')      → Error
-// ❌ pool.query('COMMIT')     → Error
-// ❌ pool.query('ROLLBACK')   → Error
-// ❌ pool.query('SAVEPOINT')  → Error
-
-// ✅ client.query('BEGIN')    → OK
-// ✅ pool.query('SELECT...')  → OK (no transaction)
-```
-
-## Let ESLint Catch This
+You don't want to rely on every engineer remembering pool-vs-client semantics.
+The rule flags a transaction-control statement issued on a pool:
 
 ```bash
 npm install --save-dev eslint-plugin-pg
 ```
 
-```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
+```js
+// eslint.config.mjs — `configs` is a NAMED export (default export is the plugin)
+import { configs } from "eslint-plugin-pg";
+
+export default [configs.recommended];
 ```
 
-The [`no-transaction-on-pool`](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-transaction-on-pool) rule catches every case:
-
-```bash
-src/transfer.ts
-  3:9  error  🔒 CWE-362 | Transaction command on pool - use pool.connect() for transactions
-               Fix: const client = await pool.connect(); client.query('BEGIN');
+```text
+src/transfer.js
+  3:9  error  ⚠️ Transactions should not be started on the Pool directly. | HIGH
+             Fix: Use "await pool.connect()" to get a client, then start the transaction on the client.
 ```
 
-## Helper Function Pattern
+(The ESLint CLI also appends the rule's doc URL to the `Fix:` line; trimmed
+here.) It catches `BEGIN`, `COMMIT`, and `ROLLBACK` on a `pool.query()` — and
+stays silent on a plain `pool.query('SELECT …')` (a single query needs no
+transaction) and on `client.query('BEGIN')` (the correct form). (The rule's own
+docs tag the narrower CWE-662, Improper Synchronization; the underlying bug class
+is the race condition, CWE-362.) It keys on a string-literal first argument to a
+`pool`-named object's `.query()`, so a transaction built from a template literal
+or held in a differently-named variable still warrants a human look.
+
+## Make it reusable
+
+Wrap the borrow→begin→commit→release dance once, and every transaction is correct
+by construction:
 
 ```javascript
-// ✅ Reusable transaction wrapper
 async function withTransaction(callback) {
   const client = await pool.connect();
   try {
@@ -140,56 +144,70 @@ async function withTransaction(callback) {
   }
 }
 
-// Usage
-await withTransaction(async (client) => {
-  await client.query("UPDATE accounts SET...", [amount, from]);
-  await client.query("UPDATE accounts SET...", [amount, to]);
-});
+await withTransaction((client) =>
+  Promise.all([
+    client.query("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [
+      amount,
+      from,
+    ]),
+    client.query("UPDATE accounts SET balance = balance + $1 WHERE id = $2", [
+      amount,
+      to,
+    ]),
+  ]),
+);
 ```
 
-## When To Use What
+## When to use what
 
-| Scenario                     | Use                                 |
-| ---------------------------- | ----------------------------------- |
-| Single query                 | `pool.query()`                      |
-| Multiple independent queries | `pool.query()`                      |
-| Transaction (BEGIN/COMMIT)   | `pool.connect()` → `client.query()` |
-| Long-running session         | `pool.connect()` → `client.query()` |
-
-## Quick Install
-
-```bash
-npm install --save-dev eslint-plugin-pg
-```
-
-```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
-```
-
-Don't let race conditions corrupt your data.
+| Scenario                       | Use                                  |
+| ------------------------------ | ------------------------------------ |
+| Single query                   | `pool.query()`                       |
+| Multiple independent queries   | `pool.query()` (no atomicity needed) |
+| Transaction (`BEGIN`/`COMMIT`) | `pool.connect()` → `client.query()`  |
+| Long-running session           | `pool.connect()` → `client.query()`  |
 
 ---
 
-📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
-📖 [Rule docs: no-transaction-on-pool](https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-pg/docs/rules/no-transaction-on-pool.md)
+## Compatibility
+
+| Surface              | Support                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                  |
+| **Node**             | `>= 18.0.0`                                                                           |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                        |
+| **`pg` driver**      | peer `^6 \|\| ^7 \|\| ^8`; AST-based, lints regardless of installed version           |
+| **Module system**    | Plugin ships CommonJS; your config can be `eslint.config.js` or `.mjs`                |
+| **Oxlint**           | Loads under Oxlint's JS-plugin runner via the `interlace-pg` port, parity-gated in CI |
+
+---
+
+## Where this fits
+
+`no-transaction-on-pool` is the atomicity member of `eslint-plugin-pg`. The rest
+of the data-layer threat model:
+
+- [The 4 ways a node-postgres data layer fails](https://ofriperetz.dev/articles/sql-injection-node-postgres-pattern) — injection, identifier hijacking, exhaustion, transport
+- [The connection leak that exhausted our pool](https://ofriperetz.dev/articles/database-connection-leak-production-outage) — the `finally`-release companion to this fix
+- [All 13 rules of `eslint-plugin-pg`](https://ofriperetz.dev/articles/getting-started-eslint-plugin-pg)
+
+---
+
+## Links
+
+- 📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
+- 📖 [Rule docs: no-transaction-on-pool](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-transaction-on-pool)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-pg)
 
 ::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
-⭐ Star on GitHub
+⭐ Star on GitHub if you've ever wrapped `pool.query("BEGIN")` and called it a transaction.
 ::
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack. `eslint-plugin-pg` is its
+node-postgres layer.
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
-
----
-
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

Rewrite of the transaction race-conditions post-mortem (was 5.7).

- **Dropped a false-coverage claim** — the original said the rule catches `SAVEPOINT`, but `TRANSACTION_KEYWORDS = ['BEGIN','COMMIT','ROLLBACK']` (no SAVEPOINT). A reader testing `pool.query('SAVEPOINT sp1')` would get zero diagnostics. Corrected to BEGIN/COMMIT/ROLLBACK.
- **Fixed the sample** — `🔒 CWE-362 | Transaction command on pool...` → the real `⚠️ Transactions should not be started on the Pool directly. | HIGH` (the rule passes no cwe/owasp/cvss/compliance, so the finding renders no CWE token). Framed the bug as race condition CWE-362 in prose, with a note reconciling the rule's meta CWE-662.
- Documented the rule's detection constraints (string-literal first arg + `pool`-named object); kept the strong "pool scatters your transaction across clients" explanation + the `withTransaction` helper; `{ configs }` named import; retitled off "Post-Mortem / (And the Guard)"; added Compatibility; dropped the cruft.

## Test plan

- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.4**, Structure **9.4**, Compatibility **9.7**, Reproducibility **9.5** (Security/Repro re-passed after the SAVEPOINT fix).
- [x] Keyword set + render verified against `no-transaction-on-pool` source.

## After merge

dev.to auto-updates via `devto_id 3138993`. Site page deploys in the final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)