### PR TITLE
docs(blog): SonarJS benchmark → 9.0+ (real re-run, quality-not-security landscape)

### DIFF
--- a/apps/blog/content/articles/benchmark-sonarjs-vs-interlace.md
+++ b/apps/blog/content/articles/benchmark-sonarjs-vs-interlace.md
@@ -1,8 +1,8 @@
 ---
 devto_url: "https://dev.to/ofri-peretz/sonarjs-has-269-rules-it-still-misses-65-of-security-vulnerabilities-3jh"
 devto_id: 3240739
-title: "SonarJS Has 269 Rules. It Still Misses 65% of Security Vulnerabilities."
-description: "A head-to-head benchmark between eslint-plugin-sonarjs and the Interlace security ecosystem. 269 rules vs 201 rules — more isn't better when 65% of vulnerabilities slip through."
+title: "SonarJS Has 269 Rules and Found 13 Security Issues Where the Domain Plugins Found 46 — It's a Quality Linter"
+description: "A reproducible 5-way benchmark: eslint-plugin-sonarjs (269 rules) vs the Interlace security plugins, on one fixture. SonarJS is one of the best quality linters in the ecosystem — and that's exactly why its security coverage is a different scope."
 slug: "benchmark-sonarjs-vs-interlace"
 published: true
 date: 2026-02-08
@@ -14,632 +14,160 @@ tags:
   - benchmark
 series: "ESLint Security Benchmark Series"
 canonical_url: https://ofriperetz.dev/articles/benchmark-sonarjs-vs-interlace
-reading_time_minutes: 12
+reading_time_minutes: 8
 author:
   name: Ofri Peretz
   avatar: https://avatars.githubusercontent.com/u/46347627
   title: Security Engineering Leader
 ---
 
-**Skip to:** [Results](#the-results) | [Every Test Case](#every-test-case-detailed-results) | [False Positives](#the-false-positive-analysis) | [Verdict](#the-verdict)
-
-## TL;DR
-
-SonarJS is an excellent code quality tool — one of the best in the ESLint ecosystem. But when we tested it specifically for **security detection**, it caught 14 out of 40 vulnerabilities while Interlace caught all 40. That's not a flaw in SonarJS — it's a scope difference. SonarJS was built for quality. Security is where dedicated tools shine.
-
-| Metric                  | eslint-plugin-sonarjs | Interlace Ecosystem  |
-| :---------------------- | :-------------------- | :------------------- |
-| **Rules**               | 269                   | 201                  |
-| **Security Detections** | 14/40 (35%)           | **40/40 (100%)**     |
-| **Missed**              | 26 vulnerabilities    | **0**                |
-| **False Alarms**        | 5                     | **0**                |
-| **F1 Score**            | 47.5%                 | **100.0%**           |
-| **Category Coverage**   | 7/14 categories       | **14/14 categories** |
-
-> 💡 **Key takeaway:** SonarJS excels at code quality, cognitive complexity, and code smell detection. But relying on it _alone_ for security leaves gaps in 7 OWASP attack categories. The best setup? **Use both** — SonarJS for quality, Interlace for security.
-
----
-
-## Why SonarJS?
-
-`eslint-plugin-sonarjs` is SonarSource's official ESLint plugin, extracted from their SonarQube/SonarCloud analysis engine. With **3M+ weekly downloads** and **269 rules**, it's one of the most popular and well-maintained ESLint plugins in the ecosystem — and for good reason.
-
-SonarJS brings enterprise-grade code quality rules to ESLint: cognitive complexity analysis, dead code detection, code smell identification, and strong security rules for categories like command injection and weak cryptography. Many teams adopt it as part of their SonarQube/SonarCloud pipeline, and it delivers real value.
-
-But SonarJS was designed as a **general-purpose quality tool** — not a dedicated security scanner. This benchmark tests a specific question: _how far does SonarJS go when your goal is comprehensive Node.js security coverage?_
-
----
-
-## Test Setup
-
-| Component         | SonarJS                 | Interlace                      |
-| :---------------- | :---------------------- | :----------------------------- |
-| **Version**       | 3.0.6                   | 3.0.2 (secure-coding lead)     |
-| **Total Rules**   | 269                     | 201 (11 security plugins)      |
-| **Configuration** | `recommended`           | `recommended` (all 11 plugins) |
-| **ESLint**        | 9.39.2                  | 9.39.2                         |
-| **Node.js**       | v20.19.5                | v20.19.5                       |
-| **Platform**      | macOS (darwin/arm64)    | Same                           |
-| **Fixtures**      | 40 vulnerable + 38 safe | Same fixtures                  |
-
-Both plugins tested with their recommended presets — the out-of-box experience a developer gets after `npm install`.
-
----
-
-## The Results
-
-### Detection Summary
-
-```
-Vulnerable Code Detections (out of 40 patterns):
-
-Interlace:   ████████████████████████████████████████  40/40 (100%)
-SonarJS:     ██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░  14/40 (35%)
-```
-
-### Category-by-Category Summary
-
-| Category              | Cases  | SonarJS    | Interlace | SonarJS Rules Triggered                                 |
-| :-------------------- | :----- | :--------- | :-------- | :------------------------------------------------------ |
-| SQL Injection         | 4      | ❌ **0/4** | ✅ 4/4    | —                                                       |
-| Command Injection     | 4      | ✅ **4/4** | ✅ 4/4    | `sonarjs/os-command`                                    |
-| Path Traversal        | 4      | ❌ **0/4** | ✅ 4/4    | —                                                       |
-| Hardcoded Credentials | 4      | ⚠️ **2/4** | ✅ 4/4    | `no-hardcoded-passwords`, `hardcoded-secret-signatures` |
-| JWT Vulnerabilities   | 3      | ⚠️ **1/3** | ✅ 3/3    | `insecure-jwt-token`                                    |
-| XSS / Code Execution  | 4      | ⚠️ **2/4** | ✅ 4/4    | `sonarjs/code-eval`                                     |
-| Prototype Pollution   | 3      | ❌ **0/3** | ✅ 3/3    | —                                                       |
-| Insecure Randomness   | 2      | ✅ **2/2** | ✅ 2/2    | `sonarjs/pseudo-random`                                 |
-| Weak Cryptography     | 3      | ⚠️ **2/3** | ✅ 3/3    | `sonarjs/hashing`                                       |
-| Timing Attacks        | 2      | ❌ **0/2** | ✅ 2/2    | —                                                       |
-| NoSQL Injection       | 2      | ❌ **0/2** | ✅ 2/2    | —                                                       |
-| SSRF                  | 2      | ❌ **0/2** | ✅ 2/2    | —                                                       |
-| Open Redirect         | 1      | ❌ **0/1** | ✅ 1/1    | —                                                       |
-| ReDoS                 | 2      | ⚠️ **1/2** | ✅ 2/2    | `sonarjs/slow-regex`                                    |
-| **TOTAL**             | **40** | **14/40**  | **40/40** | **8 unique rules**                                      |
-
-**SonarJS has zero coverage for 7 of 14 categories**: SQL injection, path traversal, prototype pollution, timing attacks, NoSQL injection, SSRF, and open redirect.
-
----
-
-## Every Test Case: Detailed Results
-
-Below is every vulnerable pattern in the benchmark, the exact code tested, and what each plugin detected.
-
-### SQL Injection (CWE-89) — SonarJS: 0/4
-
-```javascript
-// Test 1: String concatenation — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_sql_string_concat(userId) {
-  const query = "SELECT * FROM users WHERE id = '" + userId + "'";
-  return db.query(query);
-}
-// Interlace: pg/no-sql-injection, secure-coding/database-injection
-
-// Test 2: Template literal — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_sql_template_literal(email) {
-  const query = `SELECT * FROM users WHERE email = '${email}'`;
-  return db.query(query);
-}
-
-// Test 3: Dynamic column name — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_sql_dynamic_column(sortColumn) {
-  const query = `SELECT * FROM users ORDER BY ${sortColumn}`;
-  return db.query(query);
-}
-
-// Test 4: Conditional query building — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_sql_conditional(filters) {
-  let query = "SELECT * FROM products WHERE 1=1";
-  if (filters.name) {
-    query += ` AND name = '${filters.name}'`;
-  }
-  return db.query(query);
-}
-```
-
-> **Why SonarJS misses these:** SonarJS has no SQL-specific taint analysis. It doesn't track user input flowing into `db.query()` calls. Interlace uses context-aware rules that understand database client APIs.
-
-### Command Injection (CWE-78) — SonarJS: 4/4 ✅
-
-```javascript
-// Test 1: exec() with concatenation — SonarJS ✅ sonarjs/os-command | Interlace ✅
-export function vuln_cmd_exec_concat(filename) {
-  const { exec } = require("child_process");
-  exec("ls -la " + filename, callback);
-}
-// SonarJS: "Make sure that executing this OS command is safe here."
-
-// Test 2: exec() with template literal — SonarJS ✅ sonarjs/os-command | Interlace ✅
-export function vuln_cmd_exec_template(filename) {
-  const { exec } = require("child_process");
-  exec(`convert ${filename} output.png`, callback);
-}
-
-// Test 3: execSync() — SonarJS ✅ sonarjs/os-command | Interlace ✅
-export function vuln_cmd_execsync(command) {
-  const { execSync } = require("child_process");
-  return execSync(command).toString();
-}
-
-// Test 4: spawn() with shell: true — SonarJS ✅ sonarjs/os-command | Interlace ✅
-export function vuln_cmd_spawn_shell(userCommand) {
-  const { spawn } = require("child_process");
-  return spawn(userCommand, { shell: true });
-}
-```
-
-> **Credit to SonarJS:** This is its strongest category — `sonarjs/os-command` catches all 4 patterns, including the subtle `spawn({shell: true})` case.
-
-### Path Traversal (CWE-22) — SonarJS: 0/4
-
-```javascript
-// Test 1: path.join with user input — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_path_join(filename) {
-  const filepath = path.join("./uploads", filename);
-  return fs.readFileSync(filepath);
-}
-
-// Test 2: String concatenation — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_path_concat(userId) {
-  return fs.readFileSync("./data/" + userId + "/profile.json");
-}
-
-// Test 3: No validation — MISSED by SonarJS ❌ | Interlace ✅
-export async function vuln_path_no_validation(userDir) {
-  return fs.readdir(`./storage/${userDir}`);
-}
-
-// Test 4: URL pathname — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_path_url_pathname(url) {
-  const parsedUrl = new URL(url);
-  return fs.readFileSync(`./static${parsedUrl.pathname}`);
-}
-```
-
-> **Why SonarJS misses these:** SonarJS has no `fs`-aware rules. It doesn't understand that user input flowing into `fs.readFileSync()` or `fs.readdir()` is a path traversal vector. Interlace catches these with `node-security/detect-non-literal-fs-filename` and `secure-coding/path-traversal`.
-
-### Hardcoded Credentials (CWE-798) — SonarJS: 2/4
-
-```javascript
-// Test 1: Database password — SonarJS ✅ sonarjs/no-hardcoded-passwords | Interlace ✅
-export function vuln_creds_db_password() {
-  return new Pool({
-    password: "secretPassword123", // ← SonarJS: "Review this potentially hard-coded password."
-  });
-}
-
-// Test 2: API key — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_creds_api_key() {
-  const apiKey = "sk-prod-abc123def456ghi789jkl012mno345pqr678";
-  return fetch("https://api.example.com", {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
-}
-
-// Test 3: AWS credentials — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_creds_aws() {
-  AWS.config.update({
-    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
-    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-  });
-}
-
-// Test 4: JWT secret — SonarJS ✅ sonarjs/hardcoded-secret-signatures | Interlace ✅
-export function vuln_creds_jwt_secret(user) {
-  return jwt.sign(user, "my-super-secret-jwt-key-12345");
-}
-// SonarJS: "Revoke and change this password, as it is compromised."
-```
-
-> **What SonarJS misses:** It detects `password:` property patterns and JWT-signing secrets, but misses API key strings assigned to variables and AWS credential objects. It doesn't understand cloud SDK credential patterns.
-
-### JWT Vulnerabilities (CWE-757, CWE-347) — SonarJS: 1/3
-
-```javascript
-// Test 1: Algorithm "none" — SonarJS ✅ sonarjs/insecure-jwt-token | Interlace ✅
-export function vuln_jwt_alg_none(token) {
-  return jwt.verify(token, "secret", { algorithms: ["none", "HS256"] });
-}
-// SonarJS: "Use only strong cipher algorithms when verifying the signature of this JWT."
-
-// Test 2: No algorithm restriction — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_jwt_no_algorithm(token, secret) {
-  return jwt.verify(token, secret); // No algorithms specified - accepts any
-}
-// Interlace: jwt/require-algorithm-restriction
-
-// Test 3: No expiration — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_jwt_no_expiry(user) {
-  return jwt.sign(user, process.env.JWT_SECRET); // Token never expires
-}
-// Interlace: jwt/require-expiration
-```
-
-> **What SonarJS misses:** It only catches the obvious `"none"` algorithm in the array. Missing algorithm restriction and missing expiration are equally dangerous but require understanding JWT best practices — not just pattern matching.
-
-### XSS / Code Execution (CWE-79, CWE-94) — SonarJS: 2/4
-
-```javascript
-// Test 1: innerHTML — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_xss_innerhtml(userContent) {
-  document.getElementById("output").innerHTML = userContent;
-}
-// Interlace: browser-security/no-inner-html
-
-// Test 2: document.write — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_xss_document_write(userInput) {
-  document.write("<div>" + userInput + "</div>");
-}
-// Interlace: browser-security/no-document-write
-
-// Test 3: eval() — SonarJS ✅ sonarjs/code-eval | Interlace ✅
-export function vuln_xss_eval(userCode) {
-  return eval(userCode);
-}
-// SonarJS: "Make sure that this dynamic injection or execution of code is safe."
-
-// Test 4: new Function() — SonarJS ✅ sonarjs/code-eval | Interlace ✅
-export function vuln_xss_new_function(userCode) {
-  const fn = new Function(userCode);
-  return fn();
-}
-```
-
-> **What SonarJS misses:** `innerHTML` and `document.write` are classic DOM XSS vectors, but SonarJS doesn't have browser-specific DOM sink rules. Interlace's `browser-security` plugin provides dedicated DOM XSS detection.
-
-### Prototype Pollution (CWE-1321) — SonarJS: 0/3
-
-```javascript
-// Test 1: Bracket notation — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_proto_bracket(obj, key, value) {
-  obj[key] = value; // key could be "__proto__"
-  return obj;
-}
-
-// Test 2: Deep nested manipulation — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_proto_nested(obj, path, value) {
-  const keys = path.split(".");
-  let current = obj;
-  for (let i = 0; i < keys.length - 1; i++) {
-    current = current[keys[i]];
-  }
-  current[keys[keys.length - 1]] = value;
-}
-
-// Test 3: Object.assign with parsed JSON — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_proto_assign(userInput) {
-  const config = {};
-  Object.assign(config, JSON.parse(userInput));
-  return config;
-}
-```
-
-> **Why SonarJS misses these:** Prototype pollution requires understanding that user-controlled keys can poison `Object.prototype`. SonarJS has no rules for this attack class. Interlace catches all 3 with `secure-coding/detect-object-injection`.
-
-### Insecure Randomness (CWE-330) — SonarJS: 2/2 ✅
-
-```javascript
-// Test 1: Math.random() for token — SonarJS ✅ sonarjs/pseudo-random | Interlace ✅
-export function vuln_random_token() {
-  return Math.random().toString(36).substring(2);
-}
-// SonarJS: "Make sure that using this pseudorandom number generator is safe here."
-
-// Test 2: Math.random() for session — SonarJS ✅ sonarjs/pseudo-random | Interlace ✅
-export function vuln_random_session() {
-  return "session_" + Math.floor(Math.random() * 1000000);
-}
-```
-
-> **Full marks for SonarJS here** — `sonarjs/pseudo-random` correctly flags both `Math.random()` usages.
-
-### Weak Cryptography (CWE-327, CWE-328) — SonarJS: 2/3
-
-```javascript
-// Test 1: MD5 hash — SonarJS ✅ sonarjs/hashing | Interlace ✅
-export function vuln_crypto_md5(password) {
-  return crypto.createHash("md5").update(password).digest("hex");
-}
-// SonarJS: "Make sure this weak hash algorithm is not used in a sensitive context here."
-
-// Test 2: SHA1 hash — SonarJS ✅ sonarjs/hashing | Interlace ✅
-export function vuln_crypto_sha1(sensitiveData) {
-  return crypto.createHash("sha1").update(sensitiveData).digest("hex");
-}
-
-// Test 3: DES encryption — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_crypto_des(plaintext) {
-  const cipher = crypto.createCipher("des", "password");
-  return cipher.update(plaintext, "utf8", "hex") + cipher.final("hex");
-}
-// Interlace: crypto/no-weak-cipher
-```
-
-> **What SonarJS misses:** It detects weak hash algorithms (MD5, SHA1) but not weak encryption algorithms (DES). The deprecated `createCipher` API is also a red flag that goes undetected.
-
-### Timing Attacks (CWE-208) — SonarJS: 0/2
-
-```javascript
-// Test 1: Direct comparison — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_timing_direct(input, secret) {
-  return input === secret;
-}
-// Interlace: crypto/no-timing-unsafe-compare
-
-// Test 2: Token comparison — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_timing_token(userToken, storedToken) {
-  if (userToken === storedToken) {
-    return { authenticated: true };
-  }
-}
-```
-
-> **Why SonarJS misses these:** Timing attack detection requires understanding that `===` comparison on secrets leaks information through timing differences. The safe alternative is `crypto.timingSafeEqual()`.
-
-### NoSQL Injection (CWE-943) — SonarJS: 0/2
-
-```javascript
-// Test 1: MongoDB findOne with user input — MISSED by SonarJS ❌ | Interlace ✅
-export async function vuln_nosql_mongo(username) {
-  return db.collection("users").findOne({ username });
-}
-// Interlace: mongodb-security/no-raw-query
-
-// Test 2: $where operator — MISSED by SonarJS ❌ | Interlace ✅
-export async function vuln_nosql_where(userInput) {
-  return db.collection("users").find({ $where: userInput });
-}
-// Interlace: mongodb-security/no-where-string
-```
-
-### SSRF (CWE-918) — SonarJS: 0/2
-
-```javascript
-// Test 1: fetch with user URL — MISSED by SonarJS ❌ | Interlace ✅
-export async function vuln_ssrf_fetch(userUrl) {
-  const response = await fetch(userUrl);
-  return response.json();
-}
-// Interlace: browser-security/no-unvalidated-fetch
-
-// Test 2: axios with user URL — MISSED by SonarJS ❌ | Interlace ✅
-export async function vuln_ssrf_axios(endpoint) {
-  return axios.get(endpoint);
-}
-```
-
-### Open Redirect (CWE-601) — SonarJS: 0/1
-
-```javascript
-// Test 1: Express redirect — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_redirect(req, res) {
-  const returnUrl = req.query.returnTo;
-  res.redirect(returnUrl);
-}
-// Interlace: express-security/no-open-redirect
-```
-
-### ReDoS (CWE-1333) — SonarJS: 1/2
-
-```javascript
-// Test 1: Evil regex — SonarJS ✅ sonarjs/slow-regex | Interlace ✅
-export function vuln_redos_evil(input) {
-  const evilRegex = /^(a+)+$/;
-  return evilRegex.test(input);
-}
-// SonarJS: "Make sure the regex used here, which is vulnerable to super-linear runtime
-//           due to backtracking, cannot lead to denial of service."
-
-// Test 2: User-controlled regex — MISSED by SonarJS ❌ | Interlace ✅
-export function vuln_redos_user(pattern, input) {
-  const regex = new RegExp(pattern); // User controls the pattern
-  return regex.test(input);
-}
-// Interlace: secure-coding/detect-non-literal-regexp
-```
-
----
-
-## The False Positive Analysis
-
-SonarJS produced **5 false positives** — safe code patterns that were incorrectly flagged. Here's every one:
-
-### FP 1-3: Safe Command Execution Flagged as Unsafe
-
-```javascript
-// ✅ SAFE: execFile with literal arguments — SonarJS flags ❌
-export function safe_cmd_execfile_literal() {
-  const { execFile } = require("child_process");
-  return execFile("ls", ["-la", "/tmp"]);
-}
-// SonarJS sonarjs/no-os-command-from-path:
-// "Make sure the \"PATH\" variable only contains fixed, unwriteable directories."
-
-// ✅ SAFE: spawn with shell: false — SonarJS flags ❌
-export function safe_cmd_spawn_noshell() {
-  const { spawn } = require("child_process");
-  return spawn("convert", ["input.png", "output.jpg"], { shell: false });
-}
-// SonarJS sonarjs/no-os-command-from-path (same rule, same false alarm)
-
-// ✅ SAFE: execFile with validated input — SonarJS flags ❌
-export function safe_cmd_validated(format) {
-  if (!["png", "jpg", "gif"].includes(format)) {
-    throw new Error("Invalid format");
-  }
-  return execFile("convert", ["input.img", `output.${format}`]);
-}
-// SonarJS sonarjs/no-os-command-from-path (same rule, same false alarm)
-```
-
-> **The problem:** `sonarjs/no-os-command-from-path` flags **every** `execFile` and `spawn` call regardless of whether user input is involved. It can't distinguish `execFile("ls", ["-la", "/tmp"])` (safe, literal arguments) from `exec(userInput)` (dangerous). Interlace correctly passes all 3 — it understands that `execFile` with literal arguments and `spawn` with `shell: false` are the **recommended safe alternatives**.
-
-### FP 4: Safe Math.random() for Non-Security Use
-
-```javascript
-// ✅ SAFE: Math.random() for array shuffle — SonarJS flags ❌
-export function safe_random_shuffle(array) {
-  const shuffled = [...array];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
-}
-// SonarJS sonarjs/pseudo-random:
-// "Make sure that using this pseudorandom number generator is safe here."
-```
-
-> **The problem:** `Math.random()` for a Fisher-Yates shuffle is perfectly fine — it's not generating tokens or session IDs. SonarJS can't distinguish security-sensitive randomness from benign randomness. Interlace correctly passes this — it only flags `Math.random()` when it's assigned to variables named `token`, `secret`, `session`, etc.
-
-### FP 5: Safe Regex Flagged as ReDoS
-
-```javascript
-// ✅ SAFE: Simple email regex — SonarJS flags ❌
-export function safe_regex_simple(input) {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(input);
-}
-// SonarJS sonarjs/slow-regex:
-// "Make sure the regex used here, which is vulnerable to super-linear runtime
-//  due to backtracking, cannot lead to denial of service."
-```
-
-> **The problem:** This email regex is efficient — it uses negated character classes with no nested quantifiers. SonarJS incorrectly identifies it as vulnerable to super-linear backtracking. Interlace correctly passes it.
-
-### False Positive Summary
-
-| FP  | Safe Pattern                              | SonarJS Rule              | Why It's Wrong              |
-| :-- | :---------------------------------------- | :------------------------ | :-------------------------- |
-| 1   | `execFile("ls", ["-la"])`                 | `no-os-command-from-path` | Literal args, no user input |
-| 2   | `spawn("convert", [...], {shell: false})` | `no-os-command-from-path` | shell disabled explicitly   |
-| 3   | `execFile` with allowlist validation      | `no-os-command-from-path` | Input validated before use  |
-| 4   | `Math.random()` for array shuffle         | `pseudo-random`           | Non-security use case       |
-| 5   | Simple email regex                        | `slow-regex`              | No nested quantifiers       |
-
-**Interlace: 0 false positives.** Every warning is actionable.
-
----
-
-## The Verdict
-
-| Dimension              | SonarJS | Interlace | Winner           |
-| :--------------------- | :------ | :-------- | :--------------- |
-| **Total Rules**        | 269     | 201       | 🔵 SonarJS       |
-| **Security Detection** | 35%     | 100%      | 🟢 **Interlace** |
-| **False Positives**    | 5       | 0         | 🟢 **Interlace** |
-| **Category Coverage**  | 7/14    | 14/14     | 🟢 **Interlace** |
-| **ESLint 9 Support**   | ✅      | ✅        | Tie              |
-| **Active Maintenance** | ✅      | ✅        | Tie              |
-
-### Where SonarJS Excels
-
-Let's be clear: **SonarJS is an excellent tool.** Here's where it genuinely shines:
-
-**Security categories with strong coverage:**
-
-- ✅ **Command Injection**: 4/4 — `sonarjs/os-command` is best-in-class. It catches `exec`, `execSync`, and even the subtle `spawn({shell: true})` pattern.
-- ✅ **Insecure Randomness**: 2/2 — `sonarjs/pseudo-random` correctly identifies `Math.random()` in security contexts.
-- ✅ **Weak Hashing**: 2/2 — `sonarjs/hashing` reliably flags MD5 and SHA1.
-- ✅ **JWT Algorithm Confusion**: Catches the `"none"` algorithm attack via `sonarjs/insecure-jwt-token`.
-- ✅ **Code Eval**: 2/2 — `sonarjs/code-eval` detects both `eval()` and `new Function()`.
-- ✅ **ReDoS**: Catches catastrophic backtracking patterns via `sonarjs/slow-regex`.
-
-**Code quality (not covered in this benchmark):**
-
-- 🏆 **Cognitive Complexity** — One of the best implementations available.
-- 🏆 **Dead Code Detection** — Unreachable code, unused assignments, redundant boolean comparisons.
-- 🏆 **Code Smell Detection** — Duplicate branches, collapsible if-statements, identical expressions.
-- 🏆 **Bug Detection** — All-identical comparisons, useless intersections, empty collections.
-
-Both SonarJS and Interlace have quality rules — this benchmark focused exclusively on security. A head-to-head quality comparison is coming soon.
-
-### Where SonarJS Needs Help
-
-SonarJS's security coverage is focused on a few categories. For a Node.js backend, these gaps matter:
-
-- SQL Injection (0/4) — No database-aware taint analysis
-- Path Traversal (0/4) — No `fs`-aware rules
-- Prototype Pollution (0/3) — No object injection detection
-- Timing Attacks (0/2) — No constant-time comparison rules
-- NoSQL Injection (0/2) — No MongoDB-specific rules
-- SSRF (0/2) — No outbound request validation
-- Open Redirect (0/1) — No Express redirect rules
-
-These aren't flaws — they're scope gaps. SonarJS was built to cover the breadth of JavaScript quality, not the depth of Node.js security. That's where specialized plugins fill in.
-
-### Recommendation: Use Both
-
-**The best ESLint config uses SonarJS AND dedicated security plugins.** They complement each other perfectly — SonarJS handles quality, Interlace handles security:
-
-```javascript
-// eslint.config.js — Best of both worlds
+`eslint-plugin-sonarjs` is one of the best linters in the ecosystem — 269 rules,
+3M+ weekly downloads, SonarSource's analysis engine distilled into ESLint. So I
+ran it against a file of 12 vulnerability classes alongside the Interlace
+security plugins. SonarJS flagged **13** security issues on that file; the domain
+plugins flagged **46** (different finding counts on the same file — not a shared
+scorecard).
+
+That's not a knock on SonarJS. It's a **scope** result: SonarJS is a _quality_
+linter that happens to carry a handful of security rules. Security depth is a
+different product. Here's the reproducible data, and why "use both" is the real
+answer.
+
+## Detection — `vulnerable.js` (12 vulnerability classes)
+
+| Config                                  | Engine | Security findings |
+| --------------------------------------- | ------ | ----------------- |
+| Oxlint built-in                         | Oxlint | 1                 |
+| Interlace flagship rules                | Oxlint | 5                 |
+| **eslint-plugin-sonarjs** (recommended) | ESLint | **13**            |
+| eslint-plugin-security (recommended)    | ESLint | 21                |
+| Interlace (4 plugins, recommended)      | ESLint | 46                |
+
+SonarJS's 13 came from exactly the rules it ships for cross-language security
+basics: `sonarjs/os-command` (×3) + `no-os-command-from-path` (×1),
+`sonarjs/sql-queries` (×2), `sonarjs/code-eval` (×2), `sonarjs/slow-regex` (×2),
+`sonarjs/hashing` (×2), `sonarjs/pseudo-random` (×1). Those are genuinely good
+rules — `os-command` in particular is best-in-class. The same run also produced
+**25 quality findings** (`no-unused-vars`, `no-dead-store`, …) — which is the
+point: SonarJS spends its 269 rules on _quality_, and a few of them overlap
+security.
+
+The Interlace plugins surfaced 33 more findings — the **Node-specific
+depth** SonarJS has no rule for: `fs`-path traversal
+(`node-security/detect-non-literal-fs-filename`), object injection /
+prototype-pollution (`secure-coding/detect-object-injection`), PostgreSQL
+injection (`pg/no-unsafe-query`), unsafe deserialization
+(`secure-coding/no-unsafe-deserialization`), DOM XSS
+(`browser-security/no-innerhtml`), insecure comparisons, and more.
+
+## False positives — `safe-patterns.js`
+
+| Config                 | False positives                                 |
+| ---------------------- | ----------------------------------------------- |
+| eslint-plugin-sonarjs  | **0** (security)                                |
+| Oxlint built-in        | 0                                               |
+| Interlace @ Oxlint     | 0                                               |
+| Interlace @ ESLint     | 3 (a perf rule + a conservative-by-design rule) |
+| eslint-plugin-security | 5 (genuine — validated-key + path-validated)    |
+
+SonarJS is **precise** — its 10 findings on the safe file were all quality
+(`no-unused-vars`), zero security false alarms. That precision is part of why
+it's a great quality tool.
+
+## Where SonarJS is the right call
+
+- ✓ **Cognitive complexity** — one of the best implementations anywhere.
+- ✓ **Dead code / unused assignments / redundant logic** — the `no-dead-store`,
+  `no-unused-collection`, all-identical-comparison family.
+- ✓ **Code smells** — duplicate branches, collapsible conditionals.
+- ✓ **The security basics** — command injection, eval, weak hashing, insecure
+  randomness, the SQL-string and slow-regex patterns above.
+
+## Where you need domain security rules
+
+SonarJS has no rule for the Node-specific attack surface: `fs` path traversal,
+prototype pollution, NoSQL/Mongo injection, SSRF, open redirect, timing attacks,
+JWT claim validation, unsafe deserialization. Those are the gaps the
+domain plugins fill — not because SonarJS is weak, but because it was built for
+the **breadth of JavaScript quality**, not the **depth of Node.js security**.
+
+## The real answer: run both
+
+SonarJS for quality, the domain plugins for security. They don't overlap enough
+to conflict, and together they cover both axes:
+
+```js
+// eslint.config.mjs
 import sonarjs from "eslint-plugin-sonarjs";
-import secureCoding from "eslint-plugin-secure-coding";
-import nodeSecurity from "eslint-plugin-node-security";
-import pg from "eslint-plugin-pg";
-import jwt from "eslint-plugin-jwt";
+import { configs as secureCoding } from "eslint-plugin-secure-coding";
+import { configs as nodeSecurity } from "eslint-plugin-node-security";
+import { configs as pg } from "eslint-plugin-pg";
+import { configs as browserSecurity } from "eslint-plugin-browser-security";
 
 export default [
-  sonarjs.configs.recommended, // Quality ✅
-  secureCoding.configs.recommended, // Security ✅
-  nodeSecurity.configs.recommended, // Node.js security ✅
-  pg.configs.recommended, // Database security ✅
-  jwt.configs.recommended, // Auth security ✅
+  sonarjs.configs.recommended, // quality
+  secureCoding.recommended, // general security
+  nodeSecurity.recommended, // crypto, supply-chain, SSRF, fs
+  pg.recommended, // PostgreSQL
+  browserSecurity.recommended, // DOM / browser
 ];
 ```
 
----
+## Methodology — reproduce it
 
-## Methodology
-
-### Fixture Design
-
-All 40 vulnerable patterns are real-world code from production codebases, annotated with CWE identifiers and severity ratings. The 38 safe patterns are correctly-implemented secure alternatives that should NOT trigger warnings.
-
-### Reproducibility
+Honest disclosure: the fixtures are **team-authored** (`vulnerable.js`, 12
+vulnerability classes; `safe-patterns.js`, validated-safe patterns), so they
+measure coverage of the surface the Interlace rules target — run it on your own
+code for an unbiased read. Versions (measured 2026-05): `eslint@9.39`,
+`oxlint@1.67`, `eslint-plugin-sonarjs@4.0.3` (269 rules),
+`eslint-plugin-secure-coding@3.2.0`, `node-security@4.2.0`, `pg@1.4.3`,
+`browser-security@1.2.3`. Each plugin's `recommended` preset, `--format json`,
+counted by `ruleId` (security rule IDs for the security totals).
 
 ```bash
-git clone https://github.com/ofri-peretz/eslint-benchmark-suite
-cd eslint-benchmark-suite
-npm install
-npm run benchmark:fn-fp
+npm i -D eslint@9 oxlint eslint-plugin-sonarjs eslint-plugin-secure-coding \
+  eslint-plugin-node-security eslint-plugin-pg eslint-plugin-browser-security
+npx eslint --config eslint.config.sonarjs.mjs test-files/vulnerable.js --format json
+npx eslint --config eslint.config.interlace.mjs test-files/vulnerable.js --format json
+npx oxlint test-files/vulnerable.js   # Oxlint built-in row
 ```
 
-Every claim in this article comes from the [published benchmark results](https://github.com/ofri-peretz/eslint-benchmark-suite/tree/main/results/fn-fp-comparison) and can be independently verified.
+(On ESLint 8, set `ESLINT_USE_FLAT_CONFIG=true` to load `eslint.config.mjs`;
+ESLint 9+ uses flat config by default. The Interlace-flagship-on-Oxlint row is
+reproduced from the repo per the [4-way benchmark](https://ofriperetz.dev/articles/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof).)
+
+The full 4-engine version of this benchmark (ESLint + Oxlint, built-in + plugins)
+is in [the security-linter benchmark](https://ofriperetz.dev/articles/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof).
 
 ---
 
-## Part of the Benchmark Series
+## Compatibility
 
-This article is part of the [ESLint Security Benchmark Series](/articles/benchmark-17-eslint-security-plugins-compared):
-
-- **📊 [17 Plugins Benchmarked: The Full Ecosystem Report](/articles/benchmark-17-eslint-security-plugins-compared)**
-- **📖 You are here: SonarJS vs Interlace**
-- [Microsoft SDL vs Interlace: Enterprise Security Benchmark](/articles/benchmark-microsoft-sdl-vs-interlace)
-- [eslint-plugin-security Is Abandoned](/articles/eslint-plugin-security-abandoned)
-
----
-
-## Explore the Full Ecosystem
-
-> **201 security rules. 11 specialized plugins. 100% detection. 0 false positives.**
->
-> [📖 Documentation](https://eslint.interlace.tools) | [⭐ GitHub](https://github.com/ofri-peretz/eslint) | [📦 NPM](https://npmjs.com/~ofriperetz)
+| Surface              | Support                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                   |
+| **Node**             | `>= 18.0.0`                                                            |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                         |
+| **Module system**    | Plugins ship CommonJS; your config can be `eslint.config.js` or `.mjs` |
+| **Oxlint**           | Interlace flagship rules run via the `interlace-*` ports, parity-gated |
 
 ---
 
-**Next in the ESLint Security Benchmark Series:**
+## Links
 
-- 17 ESLint Security Plugins Benchmarked: The Full Ecosystem Report
-- Microsoft SDL vs Interlace: The Enterprise Security Gap
+- 📦 [secure-coding](https://www.npmjs.com/package/eslint-plugin-secure-coding) · [node-security](https://www.npmjs.com/package/eslint-plugin-node-security) · [pg](https://www.npmjs.com/package/eslint-plugin-pg) · [browser-security](https://www.npmjs.com/package/eslint-plugin-browser-security)
+- 📦 [eslint-plugin-sonarjs](https://www.npmjs.com/package/eslint-plugin-sonarjs) — the quality half
+- 📖 [Full rule docs](https://eslint.interlace.tools)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint)
 
-**Follow [@ofri-peretz](https://dev.to/ofri-peretz) to get notified.**
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if you run SonarJS for quality and want the security half to match.
+::
 
 ---
 
-**Build Securely.**
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack.
 
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev?utm_source=devto&utm_medium=article&utm_campaign=sonarjs-benchmark) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

Rebuilt the SonarJS benchmark on **reproducible** data (the old one used an unreproducible 40-case fixture + deprecated/fabricated rule names).

- **eslint-plugin-sonarjs 4.0.3** (269 rules, recommended): **13** security findings (os-command, sql-queries, code-eval, slow-regex, hashing, pseudo-random) + 25 quality findings, **0 security FPs** — the honest "great quality linter, security is a different scope" result. (Fixed the stale "0/4 SQL" — SonarJS *does* have `sql-queries`.)
- 5-way context: Interlace@ESLint **46**, eslint-plugin-security **21**, Interlace@Oxlint **5**, Oxlint built-in **1**.
- **Landscape framing** ("use both" — SonarJS for quality, domain plugins for security), no Winner columns; fixed the denominator framing (13 findings *where* domain plugins found 46, not a 13/46 fraction); real rule names; self-graded disclosure + reproducible commands; removed the cruft.

## Test plan

- [x] Freshly measured 2026-05-31 (sonarjs 4.0.3, eslint 9.39, current Interlace plugins).
- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.4**, Structure **9.1**, Compatibility **9.3**, Reproducibility **9.3**.

## After merge

dev.to auto-updates via `devto_id 3240739`. Site page deploys in the final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)