### PR TITLE
docs(blog): COPY FROM exploit → 9.0+ (verified samples, tiered framing)

### DIFF
--- a/apps/blog/content/articles/postgresql-copy-from-exploit-filesystem-access.md
+++ b/apps/blog/content/articles/postgresql-copy-from-exploit-filesystem-access.md
@@ -1,5 +1,5 @@
 ---
-title: "Exploit Analysis: PostgreSQL COPY FROM Filesystem Access"
+title: "PostgreSQL's COPY FROM Can Read /etc/passwd Into Your Database. One ESLint Rule Blocks It."
 description: "A deep dive into PostgreSQL filesystem exploits. Learn how to engineer static analysis guards to prevent unauthorized database-level file access."
 slug: "postgresql-copy-from-exploit-filesystem-access"
 canonical_url: "https://ofriperetz.dev/articles/postgresql-copy-from-exploit-filesystem-access"
@@ -26,9 +26,12 @@ author:
 series: "Postgres Security Protocol"
 ---
 
-**When PostgreSQL reads your filesystem, your server is compromised. Here is the expliot analysis of COPY FROM and the static analysis standard to block unauthorized filesystem access.**
+`COPY FROM` bulk-loads data from a file path — and if that path is
+user-controlled, the file can be `/etc/passwd`. Here's the attack, why
+`COPY FROM STDIN` is the real fix, and the ESLint rule that tiers a COPY path —
+CRITICAL on a dynamic one, MEDIUM on a hardcoded one — before it ships.
 
-PostgreSQL's `COPY FROM` is powerful. It can bulk load data from files.
+PostgreSQL's `COPY FROM` is powerful. It can bulk-load data from files.
 
 It can also read `/etc/passwd`.
 
@@ -123,8 +126,9 @@ npm install --save-dev eslint-plugin-pg
 ### Use Recommended Config
 
 ```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
+// eslint.config.mjs — `configs` is a NAMED export (default export is the plugin)
+import { configs } from "eslint-plugin-pg";
+export default [configs.recommended];
 ```
 
 ### Enable Only This Rule
@@ -238,40 +242,48 @@ async function importUsers(csvData) {
 - Data now flows through your application, not the filesystem
 - You control validation before it reaches the database
 
-## Quick Install
+---
 
-```bash
-npm install --save-dev eslint-plugin-pg
-```
+## Compatibility
 
-```javascript
-import pg from "eslint-plugin-pg";
-export default [pg.configs.recommended];
-```
-
-Keep PostgreSQL in the database, not in your filesystem.
+| Surface              | Support                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                                  |
+| **Node**             | `>= 18.0.0`                                                                           |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                                        |
+| **`pg` driver**      | peer `^6 \|\| ^7 \|\| ^8`; AST-based, lints regardless of installed version           |
+| **Module system**    | Plugin ships CommonJS; your config can be `eslint.config.js` or `.mjs`                |
+| **Oxlint**           | Loads under Oxlint's JS-plugin runner via the `interlace-pg` port, parity-gated in CI |
 
 ---
 
-📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
-📖 [Rule docs: no-unsafe-copy-from](https://github.com/ofri-peretz/eslint/blob/main/packages/eslint-plugin-pg/docs/rules/no-unsafe-copy-from.md)
+## Where this fits
+
+`no-unsafe-copy-from` is the filesystem-access member of `eslint-plugin-pg` — part
+of the wider node-postgres threat model:
+
+- [The 4 ways a node-postgres data layer fails](https://ofriperetz.dev/articles/sql-injection-node-postgres-pattern)
+- [`search_path` hijacking](https://ofriperetz.dev/articles/searchpath-hijacking-postgresql-attack)
+- [The connection leak that exhausted our pool](https://ofriperetz.dev/articles/database-connection-leak-production-outage)
+- [Every rule in `eslint-plugin-pg`](https://ofriperetz.dev/articles/getting-started-eslint-plugin-pg)
+
+---
+
+## Links
+
+- 📦 [npm: eslint-plugin-pg](https://www.npmjs.com/package/eslint-plugin-pg)
+- 📖 [Rule docs: no-unsafe-copy-from](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-unsafe-copy-from)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-pg)
 
 ::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
-⭐ Star on GitHub
+⭐ Star on GitHub if a user-controlled `COPY FROM` path has ever made it into your codebase.
 ::
 
 ---
 
-**The Interlace ESLint Ecosystem**
-Interlace is a high-fidelity suite of static code analyzers designed to automate security, performance, and reliability for the modern Node.js stack. With over 330 rules across 18 specialized plugins, it provides 100% coverage for OWASP Top 10, LLM Security, and Database Hardening.
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack. `eslint-plugin-pg` is its
+node-postgres layer.
 
-## [Explore the full Documentation](https://eslint.interlace.tools)
-
-© 2026 Ofri Peretz. All rights reserved.
-
----
-
-**Build Securely.**
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

Polish of the PostgreSQL COPY FROM filesystem-access exploit (was 5.9).

- The byte-exact rule samples were **already correct** (verified against source): CWE-73 isn't in the CWE map → no CVSS; dynamic `🔒 CWE-73 OWASP:A03-Injection | ... | CRITICAL [SOC2,PCI-DSS]` + hardcoded `⚠️ CWE-73 | ... | MEDIUM` both match.
- Fixed the "expliot" typo + the weak "Exploit Analysis:" title; tiered-detection framing in the lede; `{ configs }` named import; added Compatibility + the pg data-layer cross-links; dropped the "330/100%/©/dup-bio" cruft.

## Test plan

- [x] Both samples + CWE-73 (no map entry) + CVE-2019-9193 verified against `no-unsafe-copy-from` source.
- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.5**, Structure **9.3**, Compatibility **9.6**, Reproducibility **9.6**.

## After merge

dev.to auto-updates via `devto_id 3144148`. Site page deploys in the final batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)