### PR TITLE
docs(blog): eslint-plugin-security → 9.0+ (correct a FALSE 'unmaintained' thesis)

### DIFF
--- a/apps/blog/content/articles/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.md
+++ b/apps/blog/content/articles/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.md
@@ -1,6 +1,6 @@
 ---
-title: "eslint-plugin-security Is Unmaintained. Here's What Nobody Tells You."
-description: "eslint-plugin-security has 1.5M weekly downloads but only 13 rules and no meaningful updates since 2020. Learn why it misses 90% of vulnerabilities—including SQL injection, JWT attacks, and AI/LLM security—and what modern ESLint security plugins to use instead."
+title: "eslint-plugin-security Is the 14-Rule Generic Floor. Here's the Domain Depth to Layer on Top."
+description: "eslint-plugin-security is the foundational, generic Node security linter — 14 rules, 2.4M+ weekly downloads, actively maintained. It catches the cross-cutting classics; it isn't built for SQL, JWT, crypto, or AI depth. Here's what each layer covers and how to run them together."
 slug: "eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h"
 canonical_url: "https://ofriperetz.dev/articles/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h"
 devto_url: "https://dev.to/ofri-peretz/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h"
@@ -9,15 +9,12 @@ published_at: "2026-02-06T06:40:05Z"
 edited_at: "2026-02-06T06:54:40Z"
 cover_image: "https://ofriperetz.dev/cdn/blog-cover-image/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.png"
 social_image: "https://ofriperetz.dev/cdn/blog-cover-image/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.png"
-reading_time_minutes: 8
+reading_time_minutes: 7
 tags:
   - "security"
   - "eslint"
   - "javascript"
   - "node"
-reactions: 0
-comments: 0
-views: 0
 author:
   name: "Ofri Peretz"
   username: "ofri-peretz"
@@ -26,357 +23,128 @@ author:
 series: "ESLint Security Benchmark Series"
 ---
 
-**Skip to:** [What It Misses](#what-does-eslint-plugin-security-miss) | [The Alternative](#what-should-i-use-instead-of-eslint-plugin-security) | [Migration Guide](#rule-by-rule-migration) | [OWASP Coverage](#owasp-top-10-coverage)
-
-## TL;DR — Migrate in 60 Seconds
-
-```bash
-npm uninstall eslint-plugin-security
-npm install -D eslint-plugin-secure-coding
-```
-
-That's it. You now have **27 rules instead of 13**, with full OWASP Top 10 mapping. Add the full security ecosystem and you get **194 security rules**.
-
-**Want the full story?** Keep reading.
-
----
-
-Let's talk about the elephant in the Node.js security room.
-
-**`eslint-plugin-security`** is the most-installed ESLint security plugin. It has 1.5M+ weekly downloads. It's recommended by countless tutorials. And it's been effectively unmaintained for years.
-
-This isn't a hit piece—it's a reality check. And a thank you.
-
-`eslint-plugin-security` **pioneered** JavaScript security linting. When it launched, it was the only game in town. The maintainers did important work that inspired everything that came after.
-
-But the threat landscape has changed. Let's see where we are in 2026.
-
-## The Numbers Don't Lie
-
-| Metric                     | eslint-plugin-security | Modern Alternative |
-| -------------------------- | ---------------------- | ------------------ |
-| **Total Rules**            | 13                     | 194                |
-| **Last Meaningful Update** | 2020                   | Weekly             |
-| **OWASP Top 10 Coverage**  | Partial (~20%)         | 100%               |
-| **Flat Config Support**    | ⚠️ Limited             | ✅ Native          |
-| **AI/LLM Security Rules**  | ❌ None                | ✅ 19 rules        |
-| **PostgreSQL Rules**       | ❌ None                | ✅ 13 rules        |
-| **JWT Security Rules**     | ❌ None                | ✅ 13 rules        |
-
-The plugin was groundbreaking when it launched. But the JavaScript security landscape has changed dramatically since 2020.
-
-## Is eslint-plugin-security Still Maintained?
-
-Let's look at the actual repository:
-
-| Metric                     | Value      | What It Means                       |
-| -------------------------- | ---------- | ----------------------------------- |
-| **Last meaningful commit** | 2020       | Core rules haven't evolved          |
-| **Open issues**            | 45+        | Many from 2021-2022, unaddressed    |
-| **Open PRs**               | 12+        | Several with no maintainer response |
-| **ESLint 9 support**       | ⚠️ Partial | No native flat config exports       |
-
-> **Note:** The plugin was transferred to `eslint-community` in 2023, which extended its life. But activity remains minimal, and the rule set hasn't grown.
-
-## What Does eslint-plugin-security Miss?
-
-Let's be specific. Here are vulnerability categories the plugin **cannot detect**:
-
-### 1. Modern SQL Injection Patterns
-
-```javascript
-// ❌ NOT detected by eslint-plugin-security
-const query = `SELECT * FROM users WHERE email = '${userInput}'`;
-await pool.query(query);
-```
-
-The plugin has no PostgreSQL-aware rules. No understanding of parameterized queries. No detection of string concatenation in database contexts.
-
-**Detection:** [eslint-plugin-pg](https://eslint.interlace.tools/docs/security/plugin-pg) catches this with `pg/no-unsafe-query`.
-
-### 2. AI/LLM Vulnerabilities
-
-```javascript
-// ❌ NOT detected by eslint-plugin-security
-import { generateText } from "ai";
-
-const response = await generateText({
-  model: openai("gpt-4"),
-  prompt: userInput, // Prompt injection - no system prompt protection
-});
-```
-
-AI security didn't exist when the plugin was written. There are zero rules for prompt injection, system prompt leakage, or tool abuse.
-
-**Detection:** [eslint-plugin-vercel-ai-security](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security) provides 19 rules for Vercel AI SDK patterns.
-
-### 3. JWT Security Issues
-
-```javascript
-// ❌ NOT detected by eslint-plugin-security
-jwt.verify(token, secret, { algorithms: ["none"] }); // Algorithm confusion attack
-```
-
-JWT attacks are some of the most common vulnerabilities in Node.js applications. The plugin has no JWT-specific rules.
-
-**Detection:** [eslint-plugin-jwt](https://eslint.interlace.tools/docs/security/plugin-jwt) catches algorithm confusion, missing expiration, and weak secrets.
-
-### 4. Connection Leaks
-
-```javascript
-// ❌ NOT detected by eslint-plugin-security
-async function getUser(id) {
-  const client = await pool.connect();
-  return client.query("SELECT * FROM users WHERE id = $1", [id]);
-  // client.release() never called - connection leak
-}
-```
-
-Production outages from connection exhaustion are common. No detection.
-
-**Detection:** [`pg/no-missing-client-release`](https://eslint.interlace.tools/docs/security/plugin-pg/rules/no-missing-client-release) ensures every `connect()` has a matching `release()`.
-
-### 5. Path Traversal with Modern APIs
-
-```javascript
-// ❌ NOT detected by eslint-plugin-security
-import { readFile } from "node:fs/promises";
-const content = await readFile(`./uploads/${filename}`);
-```
-
-The plugin's path traversal detection is limited to older `fs` patterns.
-
-**Detection:** [`node-security/detect-non-literal-fs-filename`](https://eslint.interlace.tools/docs/security/plugin-node-security/rules/detect-non-literal-fs-filename) understands modern `node:fs/promises` imports and validates path safety.
-
-## The 13 Rules, Reviewed
-
-Let's look at what `eslint-plugin-security` actually provides:
-
-| Rule                                                                                                                                       | Purpose             | Still Relevant?          |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- | ------------------------ |
-| `detect-unsafe-regex`                                                                                                                      | ReDoS prevention    | ✅ Yes                   |
-| [`detect-non-literal-regexp`](https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/detect-non-literal-regexp)           | Dynamic regex       | ⚠️ Partial               |
-| `detect-buffer-noassert`                                                                                                                   | Buffer safety       | ❌ Deprecated in Node.js |
-| [`detect-child-process`](https://eslint.interlace.tools/docs/security/plugin-node-security/rules/detect-child-process)                     | Command injection   | ⚠️ Too broad             |
-| `detect-disable-mustache-escape`                                                                                                           | XSS in templates    | ⚠️ Framework-specific    |
-| [`detect-eval-with-expression`](https://eslint.interlace.tools/docs/security/plugin-node-security/rules/detect-eval-with-expression)       | eval() detection    | ✅ Yes                   |
-| `detect-no-csrf-before-method-override`                                                                                                    | CSRF ordering       | ⚠️ Express 3.x era       |
-| [`detect-non-literal-fs-filename`](https://eslint.interlace.tools/docs/security/plugin-node-security/rules/detect-non-literal-fs-filename) | Path traversal      | ⚠️ Partial               |
-| `detect-non-literal-require`                                                                                                               | Dynamic requires    | ⚠️ ESM era issue         |
-| [`detect-object-injection`](https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules/detect-object-injection)               | Prototype pollution | ✅ Yes                   |
-| `detect-possible-timing-attacks`                                                                                                           | Timing attacks      | ⚠️ High false positives  |
-| `detect-pseudoRandomBytes`                                                                                                                 | Insecure random     | ⚠️ Outdated API name     |
-| `detect-bidi-characters`                                                                                                                   | Trojan source       | ✅ Yes                   |
-
-**Verdict:** ~4 rules are still fully relevant. ~5 are partially useful. ~4 are obsolete.
-
-## Why This Matters
-
-If you're using `eslint-plugin-security` as your primary security linting:
-
-1. **You're missing ~90% of detectable vulnerabilities**
-2. **You have no OWASP Top 10 coverage map** for compliance
-3. **You have no AI/LLM protection** as your team adopts AI tools
-4. **You're running on 2020-era detection** in a 2026 threat landscape
-
-## What Should I Use Instead of eslint-plugin-security?
-
-The modern approach is **domain-specific security plugins** that understand context. Think of it as a layered security architecture:
-
-### The Security Ecosystem: 10 Plugins, 194 Rules
-
-| Category           | Plugin                                                                                                       | Rules | What It Catches                                |
-| ------------------ | ------------------------------------------------------------------------------------------------------------ | ----- | ---------------------------------------------- |
-| **🛡️ Core**        | [`eslint-plugin-secure-coding`](https://eslint.interlace.tools/docs/security/plugin-secure-coding)           | 27    | Injection, XSS, secrets, prototype pollution   |
-| **🖥️ Environment** | [`eslint-plugin-node-security`](https://eslint.interlace.tools/docs/security/plugin-node-security)           | 31    | Node.js: fs, child_process, crypto, vm, Buffer |
-|                    | [`eslint-plugin-browser-security`](https://eslint.interlace.tools/docs/security/plugin-browser-security)     | 45    | Browser: DOM XSS, postMessage, storage, CSP    |
-| **🚂 Framework**   | [`eslint-plugin-express-security`](https://eslint.interlace.tools/docs/security/plugin-express-security)     | 10    | Express: cookies, CORS, CSRF, GraphQL          |
-|                    | [`eslint-plugin-nestjs-security`](https://eslint.interlace.tools/docs/security/plugin-nestjs-security)       | 6     | NestJS: guards, validation, throttling         |
-|                    | [`eslint-plugin-lambda-security`](https://eslint.interlace.tools/docs/security/plugin-lambda-security)       | 14    | AWS Lambda: API Gateway, headers, input        |
-| **🔐 Domain**      | [`eslint-plugin-jwt`](https://eslint.interlace.tools/docs/security/plugin-jwt)                               | 13    | JWT: algorithm confusion, secrets, validation  |
-|                    | [`eslint-plugin-pg`](https://eslint.interlace.tools/docs/security/plugin-pg)                                 | 13    | PostgreSQL: SQL injection, connection leaks    |
-|                    | [`eslint-plugin-mongodb-security`](https://eslint.interlace.tools/docs/security/plugin-mongodb-security)     | 16    | MongoDB: NoSQL injection, operator attacks     |
-| **🤖 AI/LLM**      | [`eslint-plugin-vercel-ai-security`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security) | 19    | AI SDK: prompt injection, tool safety          |
-
-### Quick Start: Choose Your Stack
-
-**Node.js Backend (Express/Fastify):**
-
-```bash
-npm install -D eslint-plugin-secure-coding \
-              eslint-plugin-node-security \
-              eslint-plugin-express-security \
-              eslint-plugin-pg \
-              eslint-plugin-jwt
-```
-
-**Serverless (AWS Lambda):**
-
-```bash
-npm install -D eslint-plugin-secure-coding \
-              eslint-plugin-lambda-security \
-              eslint-plugin-pg
-```
-
-**MongoDB/Mongoose Backend:**
-
-```bash
-npm install -D eslint-plugin-secure-coding \
-              eslint-plugin-mongodb-security \
-              eslint-plugin-node-security \
-              eslint-plugin-jwt
-```
-
-**AI/LLM Applications:**
-
-```bash
-npm install -D eslint-plugin-secure-coding \
-              eslint-plugin-vercel-ai-security \
-              eslint-plugin-node-security
-```
-
-**Browser/Frontend:**
-
-```bash
-npm install -D eslint-plugin-secure-coding \
-              eslint-plugin-browser-security
-```
-
-### Does This Support ESLint 9 Flat Config?
-
-Yes. All 10 security plugins are built for the modern ESLint ecosystem with native flat config support:
-
-```javascript
-// eslint.config.js - Full security suite
-import secureCoding from "eslint-plugin-secure-coding";
-import nodeSecurity from "eslint-plugin-node-security";
-import express from "eslint-plugin-express-security";
-import pg from "eslint-plugin-pg";
-import jwt from "eslint-plugin-jwt";
+`eslint-plugin-security` is the foundational JavaScript security linter — **2.4M+
+weekly downloads**, actively maintained (4.0.0 shipped February 2026, adding
+`detect-bidi-characters` for Trojan-Source attacks). Its **14 rules** are the
+generic floor every Node project should have.
+
+The honest framing isn't "replace it" — it's that 14 _generic_ rules are a
+**floor, not a ceiling**. They catch the cross-cutting classics; they aren't
+built for the depth of SQL, JWT, crypto, or AI-agent security. The move is to
+**layer** domain rules on top. Here's exactly what the floor covers, what it
+doesn't, and how to run both.
+
+## What the 14 rules cover (the generic floor)
+
+`detect-child-process`, `detect-eval-with-expression`, `detect-non-literal-require`,
+`detect-non-literal-fs-filename`, `detect-non-literal-regexp`,
+`detect-unsafe-regex`, `detect-object-injection`, `detect-possible-timing-attacks`,
+`detect-pseudoRandomBytes`, `detect-buffer-noassert`, `detect-new-buffer`,
+`detect-disable-mustache-escape`, `detect-no-csrf-before-method-override`,
+`detect-bidi-characters`.
+
+These are real, valuable, language-level checks — command injection, eval, unsafe
+regex, the object-injection sink, timing comparisons. Every Node app benefits.
+
+## What a generic floor can't reach
+
+On a fixture of 12 Node vulnerability classes, `eslint-plugin-security` flagged
+**21** issues; the domain plugins flagged **46** (measured — see
+[the 4-way benchmark](https://ofriperetz.dev/articles/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof)).
+The 25-finding gap is **domain depth a generic ruleset has no rule for**:
+
+| Domain              | What's missing from a generic linter              | The layer that adds it                                                                                                  |
+| ------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **PostgreSQL**      | SQL injection, connection leaks, COPY exploits    | [`eslint-plugin-pg`](https://eslint.interlace.tools/docs/security/plugin-pg) (13 rules)                                 |
+| **JWT / auth**      | `alg:none`, algorithm confusion, claim validation | [`eslint-plugin-jwt`](https://eslint.interlace.tools/docs/security/plugin-jwt) (13 rules)                               |
+| **Crypto & system** | weak hashes, ECB/static-IV, SSRF, zip-slip        | [`eslint-plugin-node-security`](https://eslint.interlace.tools/docs/security/plugin-node-security) (34 rules)           |
+| **Browser / DOM**   | CSP, CORS, `innerHTML`, JWT-in-storage            | [`eslint-plugin-browser-security`](https://eslint.interlace.tools/docs/security/plugin-browser-security) (45 rules)     |
+| **AI / LLM**        | prompt injection, tool-call agency                | [`eslint-plugin-vercel-ai-security`](https://eslint.interlace.tools/docs/security/plugin-vercel-ai-security) (19 rules) |
+
+There's also a **precision** difference: on validated-safe code,
+`eslint-plugin-security` produced 5 false positives in that benchmark
+(`detect-object-injection` on allowlist-validated keys, `detect-non-literal-fs-filename`
+on path-validated reads) — it pattern-matches the sink without seeing the guard.
+The domain rules carry CWE/OWASP/CVSS metadata and AST-aware validation detection.
+
+## The layering pattern
+
+You don't have to choose. Keep the generic floor for the classics, add domain
+plugins where your stack needs depth:
+
+```js
+// eslint.config.mjs — `configs` is a NAMED export on the Interlace plugins
+import security from "eslint-plugin-security";
+import { configs as secureCoding } from "eslint-plugin-secure-coding";
+import { configs as nodeSecurity } from "eslint-plugin-node-security";
+import { configs as pg } from "eslint-plugin-pg";
+import { configs as jwt } from "eslint-plugin-jwt";
 
 export default [
-  secureCoding.configs.recommended,
-  nodeSecurity.configs.recommended,
-  express.configs.recommended,
-  pg.configs.recommended,
-  jwt.configs.recommended,
+  security.configs.recommended, // your existing eslint-plugin-security — the generic floor (14 rules)
+  secureCoding.recommended, // general OWASP source patterns
+  nodeSecurity.recommended, // crypto, supply-chain, SSRF
+  { files: ["**/db/**"], ...pg.recommended }, // PostgreSQL depth
+  jwt.recommended, // auth depth
+  // + browser-security (DOM/CSP) and vercel-ai-security (LLM) where your stack uses them
 ];
 ```
 
-## Rule-by-Rule Migration
+(The layering config keeps your already-installed `eslint-plugin-security`; the
+install below adds the domain layers.)
 
-Every `eslint-plugin-security` rule has a modern replacement:
-
-| eslint-plugin-security           | Modern Replacement                             | Plugin        |
-| -------------------------------- | ---------------------------------------------- | ------------- |
-| `detect-unsafe-regex`            | `secure-coding/no-redos-vulnerable-regex`      | secure-coding |
-| `detect-eval-with-expression`    | `node-security/detect-eval-with-expression`    | node-security |
-| `detect-child-process`           | `node-security/detect-child-process`           | node-security |
-| `detect-non-literal-fs-filename` | `node-security/detect-non-literal-fs-filename` | node-security |
-| `detect-object-injection`        | `secure-coding/detect-object-injection`        | secure-coding |
-| `detect-possible-timing-attacks` | `node-security/no-timing-unsafe-compare`       | node-security |
-| `detect-non-literal-regexp`      | `secure-coding/detect-non-literal-regexp`      | secure-coding |
-
-**But that's just the migration.** The real value is the **181 additional security rules** you gain:
-
-| Category            | Rules | Examples                                               |
-| ------------------- | ----- | ------------------------------------------------------ |
-| Browser Security    | 45    | DOM XSS, postMessage, storage, CSP                     |
-| Node.js Security    | 31    | fs, child_process, crypto, vm, Buffer                  |
-| AI/LLM Security     | 19    | Prompt injection, tool safety, streaming               |
-| MongoDB Security    | 16    | NoSQL injection, operator attacks, ODM vulnerabilities |
-| PostgreSQL          | 13    | Connection leaks, COPY exploits, search_path hijacking |
-| JWT Vulnerabilities | 13    | Algorithm 'none', missing exp, weak secrets            |
-| AWS Lambda          | 14    | API Gateway, headers, input validation                 |
-| Express.js          | 10    | Cookies, CORS, CSRF, GraphQL                           |
-| NestJS              | 6     | Guards, validation, throttling                         |
-
-## OWASP Top 10 Coverage
-
-The ultimate test of a security plugin is OWASP coverage:
-
-| OWASP 2021 Category            | eslint-plugin-security | Interlace Ecosystem |
-| ------------------------------ | ---------------------- | ------------------- |
-| A01: Broken Access Control     | ❌                     | ✅ 12 rules         |
-| A02: Cryptographic Failures    | ⚠️ 1 rule              | ✅ 15 rules         |
-| A03: Injection                 | ⚠️ 3 rules             | ✅ 45 rules         |
-| A04: Insecure Design           | ❌                     | ✅ 8 rules          |
-| A05: Security Misconfiguration | ❌                     | ✅ 18 rules         |
-| A06: Vulnerable Components     | ❌                     | ⚠️ External\*       |
-| A07: Auth Failures             | ❌                     | ✅ 22 rules         |
-| A08: Software/Data Integrity   | ⚠️ 1 rule              | ✅ 12 rules         |
-| A09: Logging Failures          | ❌                     | ✅ 6 rules          |
-| A10: SSRF                      | ❌                     | ✅ 8 rules          |
-
-_\*A06 (Vulnerable Components) requires Software Composition Analysis (SCA) tools like `npm audit`, Snyk, or Socket—not static analysis. ESLint can't detect outdated dependencies._
-
-**Total coverage:** `eslint-plugin-security` ~20% | Interlace ~100%
-
-## Ready to Upgrade?
-
-**Option 1: Quick Migration (60 seconds)**
+Or migrate the general layer to `eslint-plugin-secure-coding` (27 rules, OWASP-mapped):
 
 ```bash
-npm uninstall eslint-plugin-security
-npm install -D eslint-plugin-secure-coding
-npx eslint . --max-warnings 0
+npm install --save-dev eslint-plugin-secure-coding eslint-plugin-node-security eslint-plugin-pg eslint-plugin-jwt
 ```
 
-**Option 2: Full Security Suite (5 minutes)**
+## Where OWASP fits
 
-```bash
-npm install -D eslint-plugin-secure-coding eslint-plugin-pg \
-              eslint-plugin-jwt eslint-plugin-node-security
-```
+For the full picture of which OWASP Top 10 categories static analysis genuinely
+covers — and the two it honestly can't — see
+[the OWASP Top 10 mapping](https://ofriperetz.dev/articles/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules)
+(it's 8 of 10, not "100%"). The point isn't a coverage scoreboard; it's matching
+rule depth to your stack's real attack surface.
 
-**Option 3: See What You're Missing First**
+## A note on the incumbent
 
-Run ESLint with the new plugins on your codebase. You'll likely find vulnerabilities that were invisible before.
-
-```bash
-npx eslint . --format stylish
-```
-
----
-
-## A Note on Open Source Maintenance
-
-Maintaining open-source projects is hard, often thankless work. The `eslint-plugin-security` maintainers gave the community years of value. This article isn't criticism—it's recognition that **the community has evolved**, and our tools should too.
-
-If you use and benefit from open-source security tooling, consider [sponsoring maintainers](https://github.com/sponsors) who keep the ecosystem alive.
+`eslint-plugin-security` pioneered JavaScript security linting and is still the
+right baseline — 2.4M downloads, an `eslint-community`-maintained project that
+shipped a major version in 2026. This isn't a teardown; it's the case for
+**layering domain depth on a solid floor**.
 
 ---
 
-## The Bottom Line
+## Compatibility
 
-`eslint-plugin-security` was important. It pioneered JavaScript security linting. But we owe it to our codebases to use tools that match today's threat landscape.
+The domain layers ship the same contract:
 
-**13 rules from 2020 aren't enough for 2026.**
-
----
-
-## Explore the Full Ecosystem
-
-> **194 security rules. 10 specialized plugins. 100% OWASP Top 10 coverage.**
->
-> The Interlace ESLint Ecosystem provides comprehensive security static analysis for modern Node.js applications.
->
-> [📖 Documentation](https://eslint.interlace.tools) | [⭐ GitHub](https://github.com/ofri-peretz/eslint) | [📦 NPM](https://npmjs.com/~ofriperetz)
+| Surface              | Support                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| **Package managers** | npm, yarn, pnpm, bun                                                   |
+| **Node**             | `>= 18.0.0`                                                            |
+| **ESLint**           | `^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0`, flat config                         |
+| **Module system**    | Plugins ship CommonJS; your config can be `eslint.config.js` or `.mjs` |
+| **Oxlint**           | flagship rules run via the `interlace-*` ports, parity-gated in CI     |
 
 ---
 
-**Related Articles:**
+## Links
 
-- [Getting Started with eslint-plugin-secure-coding](/articles/getting-started-eslint-plugin-secure-coding)
-- [SQL Injection in Node.js: The Pattern 80% Get Wrong](/articles/sql-injection-node-postgres-pattern)
-- [The JWT Algorithm 'None' Attack](/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g)
-- [Mapping Your Codebase to OWASP Top 10](/articles/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules)
-- [The 30-Minute Security Audit](/articles/the-30-minute-security-audit-onboarding-a-new-codebase)
+- 📦 [eslint-plugin-secure-coding](https://www.npmjs.com/package/eslint-plugin-secure-coding) · [node-security](https://www.npmjs.com/package/eslint-plugin-node-security) · [pg](https://www.npmjs.com/package/eslint-plugin-pg) · [jwt](https://www.npmjs.com/package/eslint-plugin-jwt)
+- 📦 [eslint-plugin-security](https://www.npmjs.com/package/eslint-plugin-security) — the generic floor
+- 📖 [Full rule docs](https://eslint.interlace.tools)
+- 💻 [Source on GitHub](https://github.com/ofri-peretz/eslint)
+
+::dev-to-cta{url="https://github.com/ofri-peretz/eslint"}
+⭐ Star on GitHub if your stack needs more security depth than a generic floor.
+::
 
 ---
 
-**Build Securely.**
+I'm **Ofri Peretz**, a security engineering leader and the author of the
+Interlace ESLint ecosystem — domain-specific static analysis for security,
+reliability, and performance on the Node.js stack.
 
-I'm Ofri Peretz, a Security Engineering Leader and the architect of the Interlace Ecosystem. I build static analysis standards that automate security and performance for Node.js fleets at scale.
-
-[ofriperetz.dev](https://ofriperetz.dev?utm_source=devto&utm_medium=article&utm_campaign=security-plugin-abandoned) | [LinkedIn](https://linkedin.com/in/ofri-peretz) | [GitHub](https://github.com/ofri-peretz)
+[ofriperetz.dev](https://ofriperetz.dev) · [LinkedIn](https://linkedin.com/in/ofri-peretz) · [GitHub](https://github.com/ofri-peretz)


### PR DESCRIPTION
## Summary

**Integrity fix + promote (was 6.6).** The article's core thesis was **false**: it claimed eslint-plugin-security is "unmaintained / abandoned / no meaningful updates since 2020 / 13 rules / misses 90%" with "1.5M downloads".

Verified against npm: it shipped **4.0.0 on 2026-02-19**, has **14 rules** (incl. `detect-bidi-characters` for Trojan Source), and **2.37M weekly downloads** — **actively maintained**. Calling a real, maintained OSS project "abandoned" is false and against the landscape-not-threats rule.

- Rewrote as an honest landscape: eslint-plugin-security is the actively-maintained **generic floor** (14 rules); the domain plugins **layer** depth on top (pg/jwt/node-security/browser-security/vercel-ai).
- Uses the measured **21-vs-46** benchmark + the 5-FP precision point; layer-not-replace framing; dropped every false claim.
- The dev.to permalink slug still reads `is-unmaintained` (immutable post-publish), but the title + body no longer make that claim and explicitly state it's actively maintained.

## Test plan

- [x] Maintenance facts verified against npm (4.0.0/2026-02-19, 2.37M dl, 14 rules incl. detect-bidi-characters).
- [x] 5-reviewer panel (gate ≥9.0): Growth **9.3**, Security **9.6**, Structure **9.4**, Compatibility **9.5**, Reproducibility **9.6**.

## After merge

dev.to auto-updates via `devto_id 3237157`. The `eslint-plugin-security-abandoned` twin will be redirected. **This is the 30th article at ≥9.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)