### PR TITLE
docs(blog): branded dynamic-OG covers for the 29 flagship articles

### DIFF
--- a/apps/blog/content/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.md
+++ b/apps/blog/content/articles/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/100-owasp-llm-top-10-coverage-for-vercel-
 devto_id: 3114794
 published_at: "2025-12-19T06:00:22Z"
 edited_at: "2026-02-05T05:33:09Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2F100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.jpg"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk.jpg"
+cover_image: "https://ofriperetz.dev/og/cover/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk"
+social_image: "https://ofriperetz.dev/og/article/100-owasp-llm-top-10-coverage-for-vercel-ai-sdk"
 reading_time_minutes: 8
 tags:
   - "eslint"

--- a/apps/blog/content/articles/3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo.md
+++ b/apps/blog/content/articles/3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/3-lines-of-code-to-hack-your-vercel-ai-ap
 devto_id: 3137481
 published_at: "2025-12-31T05:51:08Z"
 edited_at: "2026-02-05T05:33:05Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2F3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo.png"
+cover_image: "https://ofriperetz.dev/og/cover/3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo"
+social_image: "https://ofriperetz.dev/og/article/3-lines-of-code-to-hack-your-vercel-ai-app-and-1-line-to-fix-it-jo"
 reading_time_minutes: 5
 tags:
   - "eslint"

--- a/apps/blog/content/articles/benchmark-microsoft-sdl-vs-interlace.md
+++ b/apps/blog/content/articles/benchmark-microsoft-sdl-vs-interlace.md
@@ -6,7 +6,8 @@ description: "A reproducible benchmark: @microsoft/eslint-plugin-sdl (17 rules, 
 slug: "benchmark-microsoft-sdl-vs-interlace"
 published: true
 date: 2026-02-08
-cover_image: https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=1200&h=630&fit=crop
+cover_image: "https://ofriperetz.dev/og/cover/benchmark-microsoft-sdl-vs-interlace"
+social_image: "https://ofriperetz.dev/og/article/benchmark-microsoft-sdl-vs-interlace"
 tags:
   - security
   - eslint

--- a/apps/blog/content/articles/benchmark-sonarjs-vs-interlace.md
+++ b/apps/blog/content/articles/benchmark-sonarjs-vs-interlace.md
@@ -6,7 +6,8 @@ description: "A reproducible 5-way benchmark: eslint-plugin-sonarjs (269 rules) 
 slug: "benchmark-sonarjs-vs-interlace"
 published: true
 date: 2026-02-08
-cover_image: https://images.unsplash.com/photo-1555949963-aa79dcee981c?w=1200&h=630&fit=crop
+cover_image: "https://ofriperetz.dev/og/cover/benchmark-sonarjs-vs-interlace"
+social_image: "https://ofriperetz.dev/og/article/benchmark-sonarjs-vs-interlace"
 tags:
   - security
   - eslint

--- a/apps/blog/content/articles/database-connection-leak-production-outage.md
+++ b/apps/blog/content/articles/database-connection-leak-production-outage.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/the-connection-leak-that-took-down-our-pr
 devto_id: 3138991
 published_at: "2025-12-31T21:35:53Z"
 edited_at: "2026-01-11T10:21:49Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fdatabase-connection-leak-production-outage.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/database-connection-leak-production-outage.png"
+cover_image: "https://ofriperetz.dev/og/cover/database-connection-leak-production-outage"
+social_image: "https://ofriperetz.dev/og/article/database-connection-leak-production-outage"
 reading_time_minutes: 5
 tags:
   - "eslint"

--- a/apps/blog/content/articles/eslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster.md
+++ b/apps/blog/content/articles/eslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/eslint-plugin-import-vs-eslint-plugin-imp
 devto_id: 3143536
 published_at: "2026-01-02T14:46:40Z"
 edited_at: "2026-02-05T05:32:55Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Feslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/eslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster.png"
+cover_image: "https://ofriperetz.dev/og/cover/eslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster"
+social_image: "https://ofriperetz.dev/og/article/eslint-plugin-import-vs-eslint-plugin-import-next-up-to-100x-faster"
 reading_time_minutes: 4
 tags:
   - "eslint"

--- a/apps/blog/content/articles/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.md
+++ b/apps/blog/content/articles/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/eslint-plugin-security-is-unmaintained-he
 devto_id: 3237157
 published_at: "2026-02-06T06:40:05Z"
 edited_at: "2026-02-06T06:54:40Z"
-cover_image: "https://ofriperetz.dev/cdn/blog-cover-image/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h.png"
+cover_image: "https://ofriperetz.dev/og/cover/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h"
+social_image: "https://ofriperetz.dev/og/article/eslint-plugin-security-is-unmaintained-heres-what-nobody-tells-you-96h"
 reading_time_minutes: 7
 tags:
   - "security"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-browser-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-browser-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-browse
 devto_id: 3143592
 published_at: "2026-01-02T15:20:36Z"
 edited_at: "2026-01-11T10:21:38Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-eslint-plugin-browser-security.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-browser-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-browser-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-browser-security"
 reading_time_minutes: 10
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-jwt.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-jwt.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-jwt-4l
 devto_id: 3143580
 published_at: "2026-01-02T15:17:19Z"
 edited_at: "2026-01-11T10:21:39Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-eslint-plugin-jwt.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-jwt.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-jwt"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-jwt"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-nestjs-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-nestjs-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-nestjs
 devto_id: 3144090
 published_at: "2026-01-02T19:28:48Z"
 edited_at: "2026-01-11T10:21:35Z"
-cover_image: "https://dev-to-uploads.s3.amazonaws.com/uploads/articles/nhu1ka6yvpqg0bpuypni.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-nestjs-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-nestjs-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-nestjs-security"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-node-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-node-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-crypto
 devto_id: 3143570
 published_at: "2026-01-02T15:15:04Z"
 edited_at: "2026-02-03T04:59:37Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-eslint-plugin-node-security.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-node-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-node-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-node-security"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-pg.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-pg.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-pg-43p
 devto_id: 3138840
 published_at: "2025-12-31T18:45:40Z"
 edited_at: "2026-01-11T10:21:52Z"
-cover_image: "https://dev-to-uploads.s3.amazonaws.com/uploads/articles/7xvyy2px23d7rolvt8kf.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-pg.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-pg"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-pg"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-secure-coding.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-secure-coding.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-secure
 devto_id: 3138988
 published_at: "2025-12-31T21:31:41Z"
 edited_at: "2026-01-11T10:21:50Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-eslint-plugin-secure-coding.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-secure-coding.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-secure-coding"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-secure-coding"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-eslint-plugin-vercel-ai-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-vercel-ai-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-vercel
 devto_id: 3139002
 published_at: "2025-12-31T21:49:06Z"
 edited_at: "2026-01-11T10:21:46Z"
-cover_image: "https://dev-to-uploads.s3.amazonaws.com/uploads/articles/rxxfvuudvh7r4bny4jxn.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-eslint-plugin-vercel-ai-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-eslint-plugin-vercel-ai-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-eslint-plugin-vercel-ai-security"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-with-eslint-plugin-express-security.md
+++ b/apps/blog/content/articles/getting-started-with-eslint-plugin-express-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-expres
 devto_id: 3144099
 published_at: "2026-01-02T19:40:18Z"
 edited_at: "2026-02-05T05:33:03Z"
-cover_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-with-eslint-plugin-express-security.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-with-eslint-plugin-express-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-with-eslint-plugin-express-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-with-eslint-plugin-express-security"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/getting-started-with-eslint-plugin-lambda-security.md
+++ b/apps/blog/content/articles/getting-started-with-eslint-plugin-lambda-security.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/getting-started-with-eslint-plugin-lambda
 devto_id: 3144087
 published_at: "2026-01-02T19:26:45Z"
 edited_at: "2026-02-05T06:02:24Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fgetting-started-with-eslint-plugin-lambda-security.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/getting-started-with-eslint-plugin-lambda-security.png"
+cover_image: "https://ofriperetz.dev/og/cover/getting-started-with-eslint-plugin-lambda-security"
+social_image: "https://ofriperetz.dev/og/article/getting-started-with-eslint-plugin-lambda-security"
 reading_time_minutes: 9
 tags:
   - "eslint"

--- a/apps/blog/content/articles/hardcoded-secrets-ai-agents-autofix.md
+++ b/apps/blog/content/articles/hardcoded-secrets-ai-agents-autofix.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/hardcoded-secrets-the-1-vulnerability-ai-
 devto_id: 3137474
 published_at: "2025-12-31T05:39:36Z"
 edited_at: "2026-01-11T10:22:03Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fhardcoded-secrets-ai-agents-autofix.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/hardcoded-secrets-ai-agents-autofix.png"
+cover_image: "https://ofriperetz.dev/og/cover/hardcoded-secrets-ai-agents-autofix"
+social_image: "https://ofriperetz.dev/og/article/hardcoded-secrets-ai-agents-autofix"
 reading_time_minutes: 7
 tags:
   - "eslint"

--- a/apps/blog/content/articles/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules.md
+++ b/apps/blog/content/articles/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/mapping-your-codebase-to-owasp-top-10-wit
 devto_id: 3138808
 published_at: "2025-12-31T18:15:25Z"
 edited_at: "2026-02-05T04:58:59Z"
-cover_image: "https://ofriperetz.dev/cdn/blog-cover-image/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules.png"
+cover_image: "https://ofriperetz.dev/og/cover/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules"
+social_image: "https://ofriperetz.dev/og/article/mapping-your-codebase-to-owasp-top-10-with-247-eslint-rules"
 reading_time_minutes: 8
 tags:
   - "eslint"

--- a/apps/blog/content/articles/n-plus-1-insert-loop-api-performance.md
+++ b/apps/blog/content/articles/n-plus-1-insert-loop-api-performance.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/the-n1-insert-loop-that-slowed-our-api-to
 devto_id: 3144119
 published_at: "2026-01-02T20:06:27Z"
 edited_at: "2026-01-11T10:21:30Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fn-plus-1-insert-loop-api-performance.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/n-plus-1-insert-loop-api-performance.png"
+cover_image: "https://ofriperetz.dev/og/cover/n-plus-1-insert-loop-api-performance"
+social_image: "https://ofriperetz.dev/og/article/n-plus-1-insert-loop-api-performance"
 reading_time_minutes: 6
 tags:
   - "eslint"

--- a/apps/blog/content/articles/postgresql-copy-from-exploit-filesystem-access.md
+++ b/apps/blog/content/articles/postgresql-copy-from-exploit-filesystem-access.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/copy-from-exploits-when-postgresql-reads-
 devto_id: 3144148
 published_at: "2026-01-02T20:36:38Z"
 edited_at: "2026-01-11T10:21:28Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fpostgresql-copy-from-exploit-filesystem-access.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/postgresql-copy-from-exploit-filesystem-access.png"
+cover_image: "https://ofriperetz.dev/og/cover/postgresql-copy-from-exploit-filesystem-access"
+social_image: "https://ofriperetz.dev/og/article/postgresql-copy-from-exploit-filesystem-access"
 reading_time_minutes: 4
 tags:
   - "eslint"

--- a/apps/blog/content/articles/searchpath-hijacking-postgresql-attack.md
+++ b/apps/blog/content/articles/searchpath-hijacking-postgresql-attack.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/searchpath-hijacking-the-postgresql-attac
 devto_id: 3144104
 published_at: "2026-01-02T19:49:31Z"
 edited_at: "2026-01-11T10:21:32Z"
-cover_image: "https://dev-to-uploads.s3.amazonaws.com/uploads/articles/09u14i6uhdwthcrjbygm.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/searchpath-hijacking-postgresql-attack.png"
+cover_image: "https://ofriperetz.dev/og/cover/searchpath-hijacking-postgresql-attack"
+social_image: "https://ofriperetz.dev/og/article/searchpath-hijacking-postgresql-attack"
 reading_time_minutes: 8
 tags:
   - "eslint"

--- a/apps/blog/content/articles/securing-ai-agents-in-the-vercel-ai-sdk.md
+++ b/apps/blog/content/articles/securing-ai-agents-in-the-vercel-ai-sdk.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/securing-ai-agents-in-the-vercel-ai-sdk-4
 devto_id: 3116469
 published_at: "2025-12-20T00:03:08Z"
 edited_at: "2026-02-05T05:33:12Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fsecuring-ai-agents-in-the-vercel-ai-sdk.jpg"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/securing-ai-agents-in-the-vercel-ai-sdk.jpg"
+cover_image: "https://ofriperetz.dev/og/cover/securing-ai-agents-in-the-vercel-ai-sdk"
+social_image: "https://ofriperetz.dev/og/article/securing-ai-agents-in-the-vercel-ai-sdk"
 reading_time_minutes: 6
 tags:
   - "eslint"

--- a/apps/blog/content/articles/sql-injection-node-postgres-pattern.md
+++ b/apps/blog/content/articles/sql-injection-node-postgres-pattern.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/sql-injection-in-node-postgres-the-patter
 devto_id: 3137480
 published_at: "2025-12-31T05:50:50Z"
 edited_at: "2026-01-11T10:22:01Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fsql-injection-node-postgres-pattern.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/sql-injection-node-postgres-pattern.png"
+cover_image: "https://ofriperetz.dev/og/cover/sql-injection-node-postgres-pattern"
+social_image: "https://ofriperetz.dev/og/article/sql-injection-node-postgres-pattern"
 reading_time_minutes: 6
 tags:
   - "eslint"

--- a/apps/blog/content/articles/the-30-minute-security-audit-onboarding-a-new-codebase.md
+++ b/apps/blog/content/articles/the-30-minute-security-audit-onboarding-a-new-codebase.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/the-30-minute-security-audit-onboarding-a
 devto_id: 3137550
 published_at: "2025-12-31T06:31:46Z"
 edited_at: "2026-02-05T05:33:15Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fthe-30-minute-security-audit-onboarding-a-new-codebase.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/the-30-minute-security-audit-onboarding-a-new-codebase.png"
+cover_image: "https://ofriperetz.dev/og/cover/the-30-minute-security-audit-onboarding-a-new-codebase"
+social_image: "https://ofriperetz.dev/og/article/the-30-minute-security-audit-onboarding-a-new-codebase"
 reading_time_minutes: 5
 tags:
   - "eslint"

--- a/apps/blog/content/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.md
+++ b/apps/blog/content/articles/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/the-jwt-algorithm-none-attack-the-vulnera
 devto_id: 3137489
 published_at: "2025-12-31T05:53:24Z"
 edited_at: "2026-02-05T05:33:16Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fthe-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g.png"
+cover_image: "https://ofriperetz.dev/og/cover/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g"
+social_image: "https://ofriperetz.dev/og/article/the-jwt-algorithm-none-attack-the-vulnerability-in-1-line-of-code-d9g"
 reading_time_minutes: 5
 tags:
   - "eslint"

--- a/apps/blog/content/articles/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.md
+++ b/apps/blog/content/articles/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/the-security-engineer-interview-cheat-she
 devto_id: 3137519
 published_at: "2025-12-31T06:10:16Z"
 edited_at: "2026-02-05T05:33:13Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fthe-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn.png"
+cover_image: "https://ofriperetz.dev/og/cover/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn"
+social_image: "https://ofriperetz.dev/og/article/the-security-engineer-interview-cheat-sheet-for-javascript-developers-pgn"
 reading_time_minutes: 6
 tags:
   - "eslint"

--- a/apps/blog/content/articles/transaction-race-conditions-begin-on-pool.md
+++ b/apps/blog/content/articles/transaction-race-conditions-begin-on-pool.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/transaction-race-conditions-why-begin-on-
 devto_id: 3138993
 published_at: "2025-12-31T21:38:13Z"
 edited_at: "2026-01-11T10:21:47Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Ftransaction-race-conditions-begin-on-pool.png"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/transaction-race-conditions-begin-on-pool.png"
+cover_image: "https://ofriperetz.dev/og/cover/transaction-race-conditions-begin-on-pool"
+social_image: "https://ofriperetz.dev/og/article/transaction-race-conditions-begin-on-pool"
 reading_time_minutes: 5
 tags:
   - "eslint"

--- a/apps/blog/content/articles/vercel-ai-sdk-prompt-injection-vulnerability.md
+++ b/apps/blog/content/articles/vercel-ai-sdk-prompt-injection-vulnerability.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/your-vercel-ai-sdk-app-has-a-prompt-injec
 devto_id: 3114770
 published_at: "2025-12-19T05:49:06Z"
 edited_at: "2026-01-11T10:22:10Z"
-cover_image: "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fofriperetz.dev%2Fcdn%2Fblog-cover-image%2Fvercel-ai-sdk-prompt-injection-vulnerability.jpg"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/vercel-ai-sdk-prompt-injection-vulnerability.jpg"
+cover_image: "https://ofriperetz.dev/og/cover/vercel-ai-sdk-prompt-injection-vulnerability"
+social_image: "https://ofriperetz.dev/og/article/vercel-ai-sdk-prompt-injection-vulnerability"
 reading_time_minutes: 7
 tags:
   - "eslint"

--- a/apps/blog/content/articles/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof.md
+++ b/apps/blog/content/articles/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof.md
@@ -7,8 +7,8 @@ devto_url: "https://dev.to/ofri-peretz/your-eslint-security-plugin-is-missing-80
 devto_id: 3117602
 published_at: "2025-12-20T16:25:32Z"
 edited_at: "2026-01-11T10:22:06Z"
-cover_image: "https://ofriperetz.dev/cdn/blog-cover-image/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof.jpg"
-social_image: "https://ofriperetz.dev/cdn/blog-cover-image/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof.jpg"
+cover_image: "https://ofriperetz.dev/og/cover/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof"
+social_image: "https://ofriperetz.dev/og/article/your-eslint-security-plugin-is-missing-80-of-vulnerabilities-i-have-proof"
 reading_time_minutes: 7
 tags:
   - "eslint"

--- a/apps/blog/src/app/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/articles/[slug]/page.tsx
@@ -34,13 +34,15 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       publishedTime: fm.published_at,
       modifiedTime: modified,
       tags: fm.tags,
-      images: [fm.cover_image ?? `/og/article/${slug}`],
+      // Social cards want the 1200x630 OG ratio: prefer social_image
+      // (/og/article), fall back to the 1000x420 dev.to cover, then the route.
+      images: [fm.social_image ?? fm.cover_image ?? `/og/article/${slug}`],
     },
     twitter: {
       card: "summary_large_image",
       title: fm.title,
       description: fm.description,
-      images: [fm.cover_image ?? `/og/article/${slug}`],
+      images: [fm.social_image ?? fm.cover_image ?? `/og/article/${slug}`],
     },
   };
 }
@@ -61,7 +63,10 @@ export default async function ArticlePage(props: PageProps) {
 
   const { frontmatter: fm } = article;
   const url = fm.canonical_url ?? `https://ofriperetz.dev/articles/${slug}`;
-  const image = fm.cover_image ?? `https://ofriperetz.dev/og/article/${slug}`;
+  const image =
+    fm.social_image ??
+    fm.cover_image ??
+    `https://ofriperetz.dev/og/article/${slug}`;
 
   const blogPostingSchema = {
     "@context": "https://schema.org",
@@ -111,8 +116,8 @@ export default async function ArticlePage(props: PageProps) {
             <img
               src={fm.cover_image}
               alt=""
-              width={1200}
-              height={630}
+              width={1000}
+              height={420}
               loading="eager"
               fetchPriority="high"
               decoding="async"


### PR DESCRIPTION
## Summary

- Swept `cover_image` / `social_image` on all **29 rewritten (≥9.0) articles** to our dynamic Satori OG routes at the two correct dimensions:
  - `cover_image` → `https://ofriperetz.dev/og/cover/<slug>` — **1000×420** (dev.to cover ratio)
  - `social_image` → `https://ofriperetz.dev/og/article/<slug>` — **1200×630** (standard OG / social card)
- Replaces a grab-bag of dev.to-proxied URLs, S3 uploads, `/cdn` PNGs, and two raw Unsplash stock photos (sonarjs, microsoft-sdl) with branded, on-brand covers generated from each article's own title + tags + reading time — zero external image dependency.
- Wired `social_image` into the article metadata so social cards use the 1200×630 OG ratio, not the 1000×420 cover:
  - `openGraph.images` / `twitter.images` / `BlogPosting` schema `image` now prefer `fm.social_image ?? fm.cover_image ?? /og/article`.
  - in-article hero `<img>` intrinsic size `1200×630` → `1000×420` so the banner title isn't cropped by `object-cover`.

## Test plan

- [x] `npm run build` — compiled, 63/63 static pages generated.
- [x] `npm run test` — 89 vitest lock tests pass (incl. `interlace-floor-lock`).
- [x] `npm run lint` — 0 errors (2 pre-existing `<img>` warnings, unchanged).
- [x] `/og/cover/<slug>` verified **200 image/png, 1000×420** live on ofriperetz.dev; `/og/article/<slug>` 200 image/png 1200×630.

## After merge

`publish-devto.yml` fires on this merge (touches `content/articles/**`) and PUTs the new `cover_image` to dev.to as `main_image`; dev.to re-proxies the now-live `/og/cover` route. A final production deploy refreshes the site covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)