### PR TITLE
ci(blog): deploy via GitHub Actions, drop Vercel Git auto-deploy/previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy production
+
+# Build + deploy entirely on GitHub Actions (free/unlimited on public repos),
+# so we never spend Vercel build minutes or preview-deploy quota. Vercel only
+# receives the *prebuilt* output. With `github.enabled: false` in vercel.json,
+# Vercel's GitHub app no longer auto-builds, previews, or posts PR statuses —
+# this workflow is the sole production-deploy path.
+#
+# Gated: the deploy steps run only after build + test + lint pass, so a broken
+# visualization or missing artifact fails CI before anything ships.
+#
+# Required repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install --no-audit --no-fund --include=optional
+
+      # ── Gates (must pass before deploy) ──────────────────────────────
+      - name: Test
+        run: npm run test
+      - name: Lint (eslint + oxlint)
+        run: npm run lint
+
+      # ── Build on GHA, deploy prebuilt output to Vercel production ─────
+      - name: Install Vercel CLI
+        run: npm i -g vercel@latest
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+        working-directory: apps/blog
+      - name: Build + deploy prebuilt to production
+        run: npm run deploy
+        working-directory: apps/blog

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -3,9 +3,7 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && rm -rf node_modules package-lock.json && npm install --no-audit --no-fund --include=optional",
   "buildCommand": "cd ../.. && npx turbo run build --filter=blog",
-  "git": {
-    "deploymentEnabled": {
-      "main": true
-    }
+  "github": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Why
Maximize GHA (free/unlimited on public repos); stop burning Vercel build/preview quota; remove the always-red **"Vercel"** preview status that was blocking PRs.

## What
- **`vercel.json`** → `github.enabled: false` — Vercel's GitHub app no longer auto-builds, previews, or posts PR commit statuses. (CLI/token deploys still work.)
- **`.github/workflows/deploy.yml`** — on push to `main`: build on GHA, then `vercel build` + `vercel deploy --prebuilt --prod`. **Gated** behind `test` + `lint` so broken visualizations/artifacts fail before deploy. Vercel only receives the prebuilt output (no Vercel build minutes).

## ⚠️ Required before merge — repo secrets (Settings → Secrets and variables → Actions)
- `VERCEL_TOKEN` — create at vercel.com/account/tokens (scope to the team)
- `VERCEL_ORG_ID` = `team_sZpUs6MAa1BKXZJY6Hq2nfnh`
- `VERCEL_PROJECT_ID` = `prj_RWemJfp8jp9sXPcabXVnIQhBi2KJ`

After merge, production deploys come **only** from `deploy.yml`. Also remove **"Vercel"** from required status checks on `main` (it disappears once the app is disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)