### PR TITLE
content(blog): drop "getting-started guide" framing in browser-security intro

### DIFF
--- a/apps/blog/content/articles/getting-started-eslint-plugin-browser-security.md
+++ b/apps/blog/content/articles/getting-started-eslint-plugin-browser-security.md
@@ -56,7 +56,7 @@ job. **`eslint-plugin-browser-security` is 45 rules for exactly that surface**,
 every one pinned to a CWE, organized into the categories you actually reason
 about (XSS, storage, transport, cookies, CORS/CSRF, postMessage, WebSocket).
 
-This is the getting-started guide: the one attack everyone gets wrong
+This is the complete reference: the one attack everyone gets wrong
 (`postMessage`), the full 45-rule map, install/config across package managers,
 and the exact ESLint/Oxlint versions it runs under.
 


### PR DESCRIPTION
## Summary

- The browser-security article's displayed title is the strong pain-hook (*"Your Frontend Stores JWTs in localStorage and Posts to '*'. 45 ESLint Rules Catch What the Backend Audit Misses."*), but the intro lead-in still called the post **"the getting-started guide"** — the exact `Getting Started with X` framing our Dev.to corpus data flags as a consistent underperformer.
- Reworded that one line to **"the complete reference,"** which matches both the title and the article's actual shape (full 45-rule map + install + compatibility = a reference, not a primer).
- **Deliberately unchanged:** `title`, `slug`, `canonical_url`, and the Dev.to permalink (`devto_id` 3143592). The slug is a cross-system join key (canonical, OG routes, corpus metrics) and Dev.to slugs are immutable & decoupled from the title — verified no sibling article links to this slug, so renaming carries cost with zero discovery upside.

## Test plan

- [x] One-line copy change in `apps/blog/content/articles/getting-started-eslint-plugin-browser-security.md`; no code, routing, or frontmatter touched.
- [x] CI + Claude Code Review run on this PR.

## After merge

The active **Publish to Dev.to** workflow fires on push to `main` (paths: `apps/blog/content/articles/**.md`) and PUT-updates the existing article (matched by `devto_id` 3143592), so the live Dev.to body picks up the reworded line automatically — no manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)